### PR TITLE
security: harden resource loading and catalog validation

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -70,6 +70,36 @@ command_exists() {
     command -v "$1" >/dev/null 2>&1
 }
 
+validate_native_package() {
+    local package=$1
+    [[ "$package" =~ ^[A-Za-z0-9][A-Za-z0-9+._:-]*$ ]]
+}
+
+validate_flatpak_id() {
+    local app_id=$1
+    [[ "$app_id" =~ ^[A-Za-z0-9_]+(\.[A-Za-z0-9_]+)+$ ]]
+}
+
+validate_exec_name() {
+    local exec_name=$1
+    [[ -z "$exec_name" || "$exec_name" =~ ^[A-Za-z0-9][A-Za-z0-9+._-]*$ ]]
+}
+
+validate_inputs() {
+    if [[ -n "$PACKAGE_NAME" ]] && ! validate_native_package "$PACKAGE_NAME"; then
+        echo "Invalid native package name: $PACKAGE_NAME" >&2
+        exit 1
+    fi
+    if [[ -n "$FLATPAK_ID" ]] && ! validate_flatpak_id "$FLATPAK_ID"; then
+        echo "Invalid Flatpak ID: $FLATPAK_ID" >&2
+        exit 1
+    fi
+    if ! validate_exec_name "$EXEC_NAME"; then
+        echo "Invalid executable name: $EXEC_NAME" >&2
+        exit 1
+    fi
+}
+
 detect_package_manager() {
     if command_exists apt-get; then
         echo "apt"
@@ -81,6 +111,8 @@ detect_package_manager() {
         echo "unknown"
     fi
 }
+
+validate_inputs
 
 PACKAGE_MANAGER=$(detect_package_manager)
 
@@ -111,19 +143,19 @@ apt_update() {
 
 apt_install() {
     if [[ "$APT_TOOL" == "nala" ]]; then
-        sudo nala install -y "$@"
+        sudo nala install -y -- "$@"
         sudo nala install -f -y
     else
-        sudo apt-get install -y "$@"
+        sudo apt-get install -y -- "$@"
         sudo apt-get install -f -y
     fi
 }
 
 apt_remove() {
     if [[ "$APT_TOOL" == "nala" ]]; then
-        sudo nala remove -y "$@"
+        sudo nala remove -y -- "$@"
     else
-        sudo apt-get remove -y "$@"
+        sudo apt-get remove -y -- "$@"
         sudo apt-get autoremove -y
     fi
 }
@@ -132,13 +164,13 @@ native_installed() {
     local package=$1
     case "$PACKAGE_MANAGER" in
         apt)
-            dpkg-query -W -f='${Status}' "$package" 2>/dev/null | grep -q "install ok installed"
+            dpkg-query -W -f='${Status}' -- "$package" 2>/dev/null | grep -q "install ok installed"
             ;;
         pacman)
-            pacman -Q "$package" >/dev/null 2>&1
+            pacman -Q -- "$package" >/dev/null 2>&1
             ;;
         dnf)
-            rpm -q "$package" >/dev/null 2>&1
+            rpm -q -- "$package" >/dev/null 2>&1
             ;;
         *)
             return 1
@@ -148,7 +180,7 @@ native_installed() {
 
 flatpak_installed() {
     local app_id=$1
-    flatpak info "$app_id" >/dev/null 2>&1
+    flatpak info -- "$app_id" >/dev/null 2>&1
 }
 
 ensure_flatpak() {
@@ -196,10 +228,10 @@ install_native() {
                 sudo sed -i '/\[multilib\]/,/Include/s/^#//' /etc/pacman.conf
             fi
             sudo pacman -Syu --noconfirm
-            sudo pacman -S --noconfirm "$package"
+            sudo pacman -S --noconfirm -- "$package"
             ;;
         dnf)
-            sudo dnf install -y "$package"
+            sudo dnf install -y -- "$package"
             ;;
     esac
 }
@@ -216,10 +248,10 @@ remove_native() {
             apt_remove "$package"
             ;;
         pacman)
-            sudo pacman -R --noconfirm "$package"
+            sudo pacman -R --noconfirm -- "$package"
             ;;
         dnf)
-            sudo dnf remove -y "$package"
+            sudo dnf remove -y -- "$package"
             ;;
     esac
 }
@@ -234,7 +266,7 @@ install_flatpak_app() {
     fi
 
     flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-    flatpak install -y flathub "$app_id"
+    flatpak install -y -- flathub "$app_id"
 }
 
 remove_flatpak_app() {
@@ -246,7 +278,7 @@ remove_flatpak_app() {
         return 0
     fi
 
-    flatpak uninstall -y "$app_id"
+    flatpak uninstall -y -- "$app_id"
 }
 
 print_header "${ACTION^} ${APP_LABEL}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     env, fs,
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     process::{Command, Stdio},
     sync::mpsc::{self, Receiver, Sender},
     thread,
@@ -68,10 +68,11 @@ impl AppEntry {
         }
     }
 
-    fn command(&self, base_dir: &Path, action: &str) -> Vec<String> {
-        vec![
+    fn command(&self, base_dir: &Path, action: &str) -> Option<Vec<String>> {
+        let main_script = resolve_resource_path(base_dir, "main.sh")?;
+        Some(vec![
             "bash".to_owned(),
-            base_dir.join("main.sh").display().to_string(),
+            main_script.display().to_string(),
             "--label".to_owned(),
             self.label.clone(),
             "--package".to_owned(),
@@ -81,7 +82,7 @@ impl AppEntry {
             "--exec".to_owned(),
             self.exec_name.clone(),
             action.to_owned(),
-        ]
+        ])
     }
 }
 
@@ -93,11 +94,9 @@ struct AdminTask {
 }
 
 impl AdminTask {
-    fn command(&self, base_dir: &Path) -> Vec<String> {
-        vec![
-            "bash".to_owned(),
-            base_dir.join(&self.script).display().to_string(),
-        ]
+    fn command(&self, base_dir: &Path) -> Option<Vec<String>> {
+        let script = resolve_resource_path(base_dir, &self.script)?;
+        Some(vec!["bash".to_owned(), script.display().to_string()])
     }
 }
 
@@ -208,28 +207,34 @@ impl ToolboxApp {
         let mut tasks = Vec::new();
 
         for index in &self.install_selected {
-            if let Some(entry) = self.apps.get(*index) {
+            if let Some(entry) = self.apps.get(*index)
+                && let Some(command) = entry.command(&self.base_dir, "install")
+            {
                 tasks.push(Task {
                     description: format!("Installing {}", entry.label),
-                    command: entry.command(&self.base_dir, "install"),
+                    command,
                 });
             }
         }
 
         for index in &self.remove_selected {
-            if let Some(entry) = self.apps.get(*index) {
+            if let Some(entry) = self.apps.get(*index)
+                && let Some(command) = entry.command(&self.base_dir, "remove")
+            {
                 tasks.push(Task {
                     description: format!("Removing {}", entry.label),
-                    command: entry.command(&self.base_dir, "remove"),
+                    command,
                 });
             }
         }
 
         for index in &self.admin_selected {
-            if let Some(task) = self.admin_tasks.get(*index) {
+            if let Some(task) = self.admin_tasks.get(*index)
+                && let Some(command) = task.command(&self.base_dir)
+            {
                 tasks.push(Task {
                     description: format!("Running {}", task.label),
-                    command: task.command(&self.base_dir),
+                    command,
                 });
             }
         }
@@ -267,10 +272,10 @@ impl ToolboxApp {
     }
 
     fn app_matches_filter(&self, entry: &AppEntry) -> bool {
-        if let Some(category) = &self.category_filter {
-            if &entry.category != category {
-                return false;
-            }
+        if let Some(category) = &self.category_filter
+            && &entry.category != category
+        {
+            return false;
         }
 
         let needle = self.search.trim().to_lowercase();
@@ -521,15 +526,12 @@ impl ToolboxApp {
                     if flat_text_button(ui, "Select All", accent_blue(), 92.0).clicked() {
                         self.select_visible_apps(true);
                     }
-                    search_field(
-                        ui,
-                        &mut self.search,
-                        if install {
-                            "Filter apps..."
-                        } else {
-                            "Filter apps..."
-                        },
-                    );
+                    let hint = if install {
+                        "Filter apps to install..."
+                    } else {
+                        "Filter apps to remove..."
+                    };
+                    search_field(ui, &mut self.search, hint);
                 });
             });
         });
@@ -2072,34 +2074,123 @@ fn page_subtitle(page: Page) -> &'static str {
 }
 
 fn find_base_dir() -> PathBuf {
-    if let Ok(exe) = env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            if dir.join("apps_config.csv").exists() {
-                return dir.to_path_buf();
-            }
+    if let Ok(override_dir) = env::var("TOOLBOX_BASE_DIR") {
+        let path = PathBuf::from(override_dir);
+        if resource_dir_has_required_files(&path) {
+            return path.canonicalize().unwrap_or(path);
         }
     }
 
-    env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+    if let Ok(exe) = env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        for candidate in dir.ancestors().take(5) {
+            if resource_dir_has_required_files(candidate) {
+                return candidate
+                    .canonicalize()
+                    .unwrap_or_else(|_| candidate.to_path_buf());
+            }
+        }
+        return dir.to_path_buf();
+    }
+
+    PathBuf::from("/usr/share/linux-it-guy-toolbox")
+}
+
+fn resource_dir_has_required_files(dir: &Path) -> bool {
+    dir.join("apps_config.csv").is_file() && dir.join("main.sh").is_file()
+}
+
+fn resolve_resource_path(base_dir: &Path, relative: &str) -> Option<PathBuf> {
+    let relative_path = Path::new(relative);
+    if relative_path.is_absolute()
+        || relative_path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return None;
+    }
+
+    let base = base_dir.canonicalize().ok()?;
+    let target = base.join(relative_path).canonicalize().ok()?;
+    target.starts_with(&base).then_some(target)
+}
+
+fn is_valid_package_name(value: &str) -> bool {
+    let mut chars = value.chars();
+    matches!(chars.next(), Some(ch) if ch.is_ascii_alphanumeric())
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '.' | '_' | ':' | '-'))
+}
+
+fn is_valid_flatpak_id(value: &str) -> bool {
+    if value.starts_with('-') || value.split('.').count() < 2 {
+        return false;
+    }
+
+    value.split('.').all(|part| {
+        let mut chars = part.chars();
+        matches!(chars.next(), Some(ch) if ch.is_ascii_alphanumeric() || ch == '_')
+            && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '_')
+    })
+}
+
+fn is_valid_exec_name(value: &str) -> bool {
+    value.is_empty()
+        || (!value.starts_with('-')
+            && value
+                .chars()
+                .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '+' | '-')))
+}
+
+fn normalize_app_entry(entry: CsvAppEntry) -> Option<AppEntry> {
+    let category = entry.category.trim().to_owned();
+    let label = entry.label.trim().to_owned();
+    let package_name = entry.package_name.trim().to_owned();
+    let flatpak_id = entry.flatpak_id.trim().to_owned();
+    let exec_name = entry.exec_name.trim().to_owned();
+    let notes = entry.notes.trim().to_owned();
+
+    if category.is_empty() || label.is_empty() || (package_name.is_empty() && flatpak_id.is_empty())
+    {
+        return None;
+    }
+    if !package_name.is_empty() && !is_valid_package_name(&package_name) {
+        return None;
+    }
+    if !flatpak_id.is_empty() && !is_valid_flatpak_id(&flatpak_id) {
+        return None;
+    }
+    if !is_valid_exec_name(&exec_name) {
+        return None;
+    }
+
+    Some(AppEntry {
+        category,
+        label,
+        package_name,
+        flatpak_id,
+        exec_name,
+        notes,
+    })
 }
 
 fn load_apps(base_dir: &Path) -> Vec<AppEntry> {
-    let path = base_dir.join("apps_config.csv");
+    let Some(path) = resolve_resource_path(base_dir, "apps_config.csv") else {
+        eprintln!("apps_config.csv was not found in a trusted resource directory.");
+        return Vec::new();
+    };
     let Ok(mut reader) = csv::Reader::from_path(path) else {
         return Vec::new();
     };
 
     reader
         .deserialize::<CsvAppEntry>()
-        .filter_map(Result::ok)
-        .filter(|entry| !entry.category.trim().is_empty() && !entry.label.trim().is_empty())
-        .map(|entry| AppEntry {
-            category: entry.category.trim().to_owned(),
-            label: entry.label.trim().to_owned(),
-            package_name: entry.package_name.trim().to_owned(),
-            flatpak_id: entry.flatpak_id.trim().to_owned(),
-            exec_name: entry.exec_name.trim().to_owned(),
-            notes: entry.notes.trim().to_owned(),
+        .filter_map(|entry| match entry {
+            Ok(entry) => normalize_app_entry(entry),
+            Err(error) => {
+                eprintln!("Skipping invalid app catalog row: {error}");
+                None
+            }
         })
         .collect()
 }
@@ -2293,4 +2384,66 @@ fn strip_ansi(input: &str) -> String {
     }
 
     output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_safe_native_package_names() {
+        assert!(is_valid_package_name("firefox"));
+        assert!(is_valid_package_name("libxcb-render0-dev"));
+        assert!(is_valid_package_name("foo.bar+baz:amd64"));
+        assert!(!is_valid_package_name("-oProxyCommand=evil"));
+        assert!(!is_valid_package_name("bad package"));
+        assert!(!is_valid_package_name("bad;package"));
+        assert!(!is_valid_package_name(""));
+    }
+
+    #[test]
+    fn validates_safe_flatpak_ids() {
+        assert!(is_valid_flatpak_id("org.mozilla.firefox"));
+        assert!(is_valid_flatpak_id("com.visualstudio.code"));
+        assert!(!is_valid_flatpak_id("-bad.option"));
+        assert!(!is_valid_flatpak_id("bad"));
+        assert!(!is_valid_flatpak_id("bad id.with.space"));
+        assert!(!is_valid_flatpak_id(""));
+    }
+
+    #[test]
+    fn rejects_catalog_entries_without_install_targets() {
+        let entry = CsvAppEntry {
+            category: "Utilities".to_owned(),
+            label: "Broken".to_owned(),
+            package_name: "".to_owned(),
+            flatpak_id: "".to_owned(),
+            exec_name: "broken".to_owned(),
+            notes: "".to_owned(),
+        };
+
+        assert!(normalize_app_entry(entry).is_none());
+    }
+
+    #[test]
+    fn rejects_catalog_entries_with_option_like_targets() {
+        let entry = CsvAppEntry {
+            category: "Utilities".to_owned(),
+            label: "Dangerous".to_owned(),
+            package_name: "--bad-option".to_owned(),
+            flatpak_id: "".to_owned(),
+            exec_name: "dangerous".to_owned(),
+            notes: "".to_owned(),
+        };
+
+        assert!(normalize_app_entry(entry).is_none());
+    }
+
+    #[test]
+    fn resolves_resources_inside_base_dir_only() {
+        let base = std::env::current_dir().expect("test cwd");
+        assert!(resolve_resource_path(&base, "main.sh").is_some());
+        assert!(resolve_resource_path(&base, "../main.sh").is_none());
+        assert!(resolve_resource_path(&base, "/tmp/main.sh").is_none());
+    }
 }


### PR DESCRIPTION
# security: harden resource loading and catalog validation

## Summary

This PR hardens the paths and data that are used to execute privileged toolbox tasks.

Changes:
- Resolve `main.sh`, `apps_config.csv`, and admin scripts through a trusted resource directory instead of blindly joining paths.
- Reject resource paths that are absolute, contain `..`, or escape the application base directory.
- Validate catalog package names, Flatpak IDs, and executable names before using them to build commands.
- Reject catalog rows with no install target.
- Add `--` separators for native package manager and Flatpak commands where appropriate.
- Add regression tests for package validation, Flatpak ID validation, empty install targets, option-like targets, and resource path traversal.
- Fix existing clippy warnings so the stricter CI added in the release PR can pass.

## Why

The app executes local scripts with elevated privileges. If an attacker can influence the working directory, catalog file, or script path, that can become a privilege-boundary issue. This PR reduces that attack surface by loading only trusted resources and validating catalog data before it reaches shell/package-manager helpers.

## Test plan

Locally verified:

```bash
cargo fmt -- --check
cargo clippy --locked --all-targets -- -D warnings
cargo test --locked
bash -n *.sh "VMware Player Fix/vmware-fix.sh"
```

Result: all passed. Rust tests: 5 passed.

## Notes

This PR does not fully redesign privilege handling. A future hardening step should replace the GUI-collected sudo password flow with a smaller privileged helper, polkit/pkexec, or another OS-native elevation model.