### PR TITLE
ci: add Dependabot, CodeQL, and security documentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "main"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "TheLinuxITGuy"
+    assignees:
+      - "TheLinuxITGuy"
+    labels:
+      - "dependencies"
+      - "rust"
+    commit-message:
+      prefix: "cargo"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    target-branch: "main"
+    reviewers:
+      - "TheLinuxITGuy"
+    assignees:
+      - "TheLinuxITGuy"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1"
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Rust
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libxcb-render0-dev \
+            libxcb-shape0-dev \
+            libxcb-xfixes0-dev \
+            libxkbcommon-dev \
+            libssl-dev
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: rust
+
+      - name: Build
+        run: cargo build --locked
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,79 @@
+# Security Policy
+
+## Permissions requises
+
+L'application a besoin des privilèges suivants pour fonctionner :
+
+| Permission | Pourquoi | Portée | Code concerné |
+|-----------|----------|--------|---------------|
+| `sudo` / root | Installer/désinstaller des paquets natifs et Flatpak, exécuter des scripts admin | Temporaire, par tâche | `src/main.rs` → `run_selected()`, `main.sh` |
+| Accès réseau | Télécharger les paquets depuis les dépôts (apt, pacman, dnf, flatpak) | Pendant l'installation | Appels package manager dans `main.sh` |
+| Lecture fichiers locaux | Lire `apps_config.csv`, les scripts shell, les assets | Répertoire de base de l'app uniquement | `src/main.rs` → `load_apps()`, `find_base_dir()` |
+| Écriture fichiers système | Modifier les paquets installés via le gestionnaire de paquets | Via le gestionnaire de paquets | `main.sh` → `install_native()`, `remove_native()` |
+
+## Flux d'élévation de privilèges
+
+```
+┌──────────────┐     ┌───────────────┐     ┌──────────────────┐
+│  GUI (egui)  │────▶│  Thread dédié │────▶│  sudo -S bash    │
+│  password    │     │  stdin pipe   │     │  main.sh ...     │
+│  TextEdit    │     │               │     │                  │
+└──────────────┘     └───────────────┘     └────────┬─────────┘
+                                                    │
+                                          ┌─────────▼─────────┐
+                                          │ Package Manager   │
+                                          │ (apt/pacman/dnf)  │
+                                          └───────────────────┘
+```
+
+### Détail du flux
+
+1. L'utilisateur sélectionne des tâches et clique **Run Selected Tasks**
+2. Une fenêtre modale demande le mot de passe sudo
+3. Le mot de passe est stocké dans un `String` en mémoire (jamais écrit sur disque)
+4. Un thread dédié lance les commandes une par une :
+   ```rust
+   let mut child = Command::new("sudo")
+       .arg("-S")                         // lire mot de passe depuis stdin
+       .arg("bash")
+       .arg(script_path)
+       .arg("--label").arg(&entry.label)
+       .arg("--package").arg(&entry.package_name)
+       // ...
+       .stdin(Stdio::piped())
+       .stdout(Stdio::piped())
+       .stderr(Stdio::piped())
+       .spawn()?;
+
+   // Transmission du mot de passe via le pipe stdin
+   child.stdin.as_mut().unwrap()
+       .write_all(password.as_bytes())?;
+   child.stdin.take();                    // fermer stdin après envoi
+   ```
+5. La sortie stdout/stderr est affichée en temps réel dans la zone de log
+6. Le `String` contenant le mot de passe est libéré automatiquement à la fin du scope
+
+## Risques connus
+
+| Risque | Sévérité | Statut |
+|--------|----------|--------|
+| Mot de passe en clair dans un `String` Rust non protégé | Medium | Accepté temporairement — migration vers `secrets` crate ou polkit prévue |
+| `sudo -S` moins sûr que polkit/pkexec | Medium | Migration recommandée dans une PR future |
+| Exécution de scripts avec privilèges root complets | Medium | Helper privilégié minimal à envisager |
+| Fallback `current_dir()` dans `find_base_dir()` | High | **Corrigé** dans PR #6 |
+| Pas de validation des noms de paquets | High | **Corrigé** dans PR #6 |
+
+## Signaler une vulnérabilité
+
+Si vous découvrez un problème de sécurité :
+
+1. **Ne créez pas d'issue publique** si la vulnérabilité est sensible
+2. Contactez l'auteur directement
+3. Pour les problèmes non sensibles, ouvrez une issue avec le tag `security`
+
+## Versions supportées
+
+| Version | Support |
+|---------|---------|
+| main (dernier commit) | ✅ Support actif |
+| Releases taggées | ✅ Corrections de sécurité backportées au cas par cas |

--- a/SECURITY_MODEL.md
+++ b/SECURITY_MODEL.md
@@ -1,0 +1,85 @@
+# Modèle d'exécution et flux sudo
+
+## Architecture
+
+```
+┌─────────────────┐     ┌──────────────┐     ┌─────────────────┐
+│   Interface GUI │────▶│   main.sh    │────▶│ Package Manager │
+│   (Rust/egui)   │     │   (Bash)     │     │ (apt/pacman/dnf)│
+└────────┬────────┘     └──────┬───────┘     └────────┬────────┘
+         │                     │                       │
+         └─── mot de passe ────┴─── sudo -S ──────────┘
+              (stdin pipe)
+```
+
+## Étapes d'exécution
+
+1. L'utilisateur sélectionne des apps ou tâches admin dans l'UI
+2. Il clique "Run Selected Tasks"
+3. L'UI affiche un champ de mot de passe sudo
+4. Au clic sur "Execute" :
+   - Les commandes sont construites (`bash main.sh --label ... --package ... install`)
+   - Chaque commande reçoit le mot de passe via `sudo -S`
+   - Les tâches s'exécutent séquentiellement dans un thread dédié
+   - La sortie stdout/stderr est affichée en temps réel dans le log
+
+## Chemins et ressources
+
+L'application localise ses ressources (`apps_config.csv`, `main.sh`, scripts admin) en remontant depuis l'exécutable ou via le répertoire de travail. Voir `src/main.rs → find_base_dir()`.
+
+## Gestion du mot de passe
+
+```rust
+// src/main.rs — extrait simplifié
+let mut child = Command::new("sudo")
+    .arg("-S")                    // lire le mot de passe depuis stdin
+    .arg("bash")
+    .arg(script_path)
+    .stdin(Stdio::piped())
+    .spawn()?;
+
+child.stdin.as_mut().unwrap()
+    .write_all(password.as_bytes())?;
+child.stdin.take();               // fermer stdin après envoi
+```
+
+Le mot de passe est conservé en mémoire dans un `String`, transmis au processus enfant, puis le `String` est libéré à la fin du scope.
+
+## Construction des commandes
+
+Toutes les commandes suivent un format fixe :
+
+**Apps du catalogue :**
+```
+sudo -S bash <main.sh> --label "Firefox" --package "firefox" --flatpak "" --exec "firefox" install
+```
+
+**Tâches admin :**
+```
+sudo -S bash <update-system.sh>
+```
+
+Aucune commande n'est construite à partir de saisies utilisateur libres. Les paramètres viennent exclusivement de `apps_config.csv` (validé) ou de la liste statique des tâches admin.
+
+## Communication inter-threads
+
+```
+┌─────────┐    mpsc::channel    ┌──────────────┐
+│ Thread   │───────────────────▶│ Thread        │
+│ worker   │   TaskUpdate enum  │ principal     │
+│ (sudo)   │                    │ (GUI egui)    │
+└─────────┘                    └──────────────┘
+
+TaskUpdate:
+  - Line(String)        → nouvelle ligne de sortie
+  - TaskCompleted(usize) → tâche N terminée
+  - AllDone             → toutes les tâches finies
+  - Error(String)       → erreur fatale
+```
+
+## Risques connus et améliorations futures
+
+- **Mot de passe en mémoire non protégé** : le `String` peut être swappé sur disque ou lu par un débogueur. Utiliser `secrets` crate avec `mlock` ou `madvise(MADV_DONTDUMP)`.
+- **`sudo -S`** : transmet le mot de passe en clair via un pipe. `pkexec`/polkit offrirait une isolation plus forte (agent système, pas de mot de passe dans le processus applicatif).
+- **Privilèges root complets** : les scripts s'exécutent en tant que root sans restriction. Un helper privilégié minimal (setuid ou daemon D-Bus) limiterait la surface d'attaque.
+- **Séquentiel uniquement** : les tâches sont exécutées une par une. Pas de parallélisme. C'est un choix conservateur acceptable pour un outil desktop.


### PR DESCRIPTION
# ci: add Dependabot, CodeQL, and security documentation

## Summary

This PR completes the remaining items from the GitHub best-practices checklist:

| # | Pratique | État |
|---|----------|------|
| 9 | Dependabot | ✓ |
| 10 | CodeQL | ✓ |
| 11 | Documentation des permissions | ✓ |
| 12 | Documentation du login/sync | ✓ |

Changes:

### Dependabot (`.github/dependabot.yml`)
- Cargo dependencies checked weekly (Monday)
- GitHub Actions checked weekly
- Max 5 open PRs at a time
- Automatic labels: `dependencies`, `rust`, `ci`

### CodeQL (`.github/workflows/codeql.yml`)
- Analyzes Rust code on push to main, PRs, and weekly schedule
- Installs system deps (libxcb, libxkbcommon, libssl) before build
- Uses `cargo build --locked` for analysis
- Results published as security alerts

### Documentation
- `SECURITY.md`: permissions table, sudo flow description, vulnerability reporting
- `SECURITY_MODEL.md`: complete execution model with architecture diagram, step-by-step flow, code excerpts, known risks and future improvements

## Test plan

### YAML validation
```bash
python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/codeql.yml'))"
```
Both pass.

### CI integration
These workflows are additive and won't break existing CI. Dependabot runs on its own schedule. CodeQL runs on push/PR/schedule.

### Documentation
- `SECURITY.md` is picked up by GitHub's Security tab automatically.
- `SECURITY_MODEL.md` provides deep technical context for reviewers and contributors.