### PR TITLE
Home · Recipes · System follow-on (Lumen Dark)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use catalog::{AdminTask, AppEntry, CatalogLoad, Task, admin_tasks, find_base_dir
 use runner::{RunnerMessage, run_tasks};
 use system::{
     RemovableApp, RemovableSource, command_output, detect_package_manager, distro_name,
-    env_or_unknown, scan_removable_apps, strip_ansi, uptime,
+    env_or_unknown, scan_removable_apps, strip_ansi, uptime, uptime_compact,
 };
 use theme::{Palette, ThemeMode};
 use validate::{is_exec_name, is_label, zeroize_string};
@@ -110,8 +110,8 @@ const SEARCH_HEIGHT: f32 = 44.0;
 const DOCK_MIN_WIDTH: f32 = 420.0;
 const DOCK_RADIUS: f32 = 20.0;
 const CONTENT_TWO_COL: f32 = 720.0;
-const INTENT_HEIGHT: f32 = 128.0;
-const GLANCE_HEIGHT: f32 = 96.0;
+const INTENT_HEIGHT: f32 = 136.0;
+const GLANCE_HEIGHT: f32 = 88.0;
 const TITLE_SIZE: f32 = 26.0;
 const FRESH_SETUP_LABELS: &[&str] = &["Update System", "Fastfetch"];
 const LAPTOP_POWER_LABELS: &[&str] = &["TLP (Laptops)", "Powertop"];
@@ -941,8 +941,8 @@ impl ToolboxApp {
         [
             ("OS", self.distro_name.clone()),
             ("Kernel", self.kernel.clone()),
-            ("Uptime", uptime()),
-            ("PM", self.package_manager.clone()),
+            ("Uptime", uptime_compact()),
+            ("Packages", self.package_manager.clone()),
         ]
     }
 
@@ -1015,7 +1015,7 @@ impl ToolboxApp {
                     (
                         Glyph::Bolt,
                         "Fresh setup",
-                        "One recipe for a new distro hop — essentials ready.",
+                        "Jump to Recipes for essentials after a distro hop.",
                     ),
                     (
                         Glyph::Briefcase,
@@ -2000,32 +2000,32 @@ fn intent_card(
     let (rect, response) = ui.allocate_exact_size(vec2(width, INTENT_HEIGHT), Sense::click());
     paint_surface_card(ui.painter(), rect, response.hovered(), palette);
 
-    let well = Rect::from_min_size(rect.min + vec2(16.0, 16.0), vec2(36.0, 36.0));
-    ui.painter().rect_filled(well, 10.0, palette.icon_well);
-    paint_glyph(ui.painter(), well.shrink(8.0), glyph, palette.accent);
+    let well = Rect::from_min_size(rect.min + vec2(20.0, 18.0), vec2(40.0, 40.0));
+    ui.painter().rect_filled(well, 12.0, palette.icon_well);
+    paint_glyph(ui.painter(), well.shrink(9.0), glyph, palette.accent);
 
     let painter = ui.painter();
-    let text_left = rect.min.x + 16.0;
-    let text_width = (rect.width() - 32.0).max(24.0);
+    let text_left = rect.min.x + 20.0;
+    let text_width = (rect.width() - 40.0).max(24.0);
     painter.text(
-        pos2(text_left, rect.min.y + 68.0),
-        Align2::LEFT_CENTER,
+        pos2(text_left, rect.min.y + 72.0),
+        Align2::LEFT_TOP,
         title,
         FontId::proportional(15.0),
         palette.text,
     );
     let galley = painter.layout(
         body.to_owned(),
-        FontId::proportional(12.0),
+        FontId::proportional(12.5),
         palette.muted,
         text_width,
     );
     painter
         .with_clip_rect(Rect::from_min_size(
-            pos2(text_left, rect.min.y + 82.0),
-            vec2(text_width, 34.0),
+            pos2(text_left, rect.min.y + 94.0),
+            vec2(text_width, 30.0),
         ))
-        .galley(pos2(text_left, rect.min.y + 82.0), galley, palette.muted);
+        .galley(pos2(text_left, rect.min.y + 94.0), galley, palette.muted);
     response
 }
 
@@ -2046,24 +2046,25 @@ fn metric_tile(
     paint_surface_card(ui.painter(), rect, response.hovered() && clickable, palette);
     let painter = ui.painter();
     painter.text(
-        pos2(rect.min.x + 16.0, rect.min.y + 22.0),
-        Align2::LEFT_CENTER,
+        pos2(rect.min.x + 18.0, rect.min.y + 18.0),
+        Align2::LEFT_TOP,
         label,
         FontId::proportional(11.0),
         palette.muted,
     );
-    painter.text(
-        pos2(rect.min.x + 16.0, rect.min.y + 48.0),
-        Align2::LEFT_CENTER,
-        value,
+    let value_pos = pos2(rect.min.x + 18.0, rect.min.y + 40.0);
+    let galley = painter.layout(
+        value.to_owned(),
         FontId::proportional(20.0),
         palette.text,
+        (rect.width() - 36.0).max(24.0),
     );
-    let bar = Rect::from_min_size(
-        pos2(rect.min.x + 16.0, rect.bottom() - 18.0),
-        vec2(36.0, 3.0),
-    );
-    painter.rect_filled(bar, 2.0, palette.accent);
+    painter
+        .with_clip_rect(Rect::from_min_size(
+            value_pos,
+            vec2((rect.width() - 36.0).max(24.0), 36.0),
+        ))
+        .galley(value_pos, galley, palette.text);
     response
 }
 
@@ -3068,7 +3069,7 @@ mod tests {
         assert_eq!(metrics[0].0, "OS");
         assert_eq!(metrics[1].0, "Kernel");
         assert_eq!(metrics[2].0, "Uptime");
-        assert_eq!(metrics[3].0, "PM");
+        assert_eq!(metrics[3].0, "Packages");
         assert_eq!(metrics[0].1, "Debian");
         assert_eq!(metrics[1].1, "6.12.0-test");
         assert_eq!(metrics[3].1, "apt-get");
@@ -3087,6 +3088,9 @@ mod tests {
         assert!(home.contains("go_fresh_setup"));
         assert!(home.contains("go_laptop_power"));
         assert!(home.contains("go_system"));
+        assert!(home.contains("Jump to Recipes for essentials after a distro hop."));
+        assert!(home.contains("Browse the catalog and stage what you need."));
+        assert!(home.contains("TLP + Powertop tuned so the battery lasts."));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,13 +107,13 @@ const CARD_GAP: f32 = 12.0;
 const CARD_RADIUS: f32 = 12.0;
 const CHECK_SIZE: f32 = 22.0;
 const SEARCH_HEIGHT: f32 = 44.0;
-const DOCK_MIN_WIDTH: f32 = 420.0;
-const DOCK_RADIUS: f32 = 20.0;
+const DOCK_MIN_WIDTH: f32 = 520.0;
+const DOCK_RADIUS: f32 = 22.0;
 const CONTENT_TWO_COL: f32 = 720.0;
-const INTENT_HEIGHT: f32 = 136.0;
-const GLANCE_HEIGHT: f32 = 88.0;
+const INTENT_HEIGHT: f32 = 148.0;
+const GLANCE_HEIGHT: f32 = 80.0;
 const RECIPE_CARD_HEIGHT: f32 = 148.0;
-const RECIPE_PIP: f32 = 16.0;
+const RECIPE_PIP: f32 = 14.0;
 const TITLE_SIZE: f32 = 26.0;
 const FRESH_SETUP_LABELS: &[&str] = &["Update System", "Fastfetch"];
 const LAPTOP_POWER_LABELS: &[&str] = &["TLP (Laptops)", "Powertop"];
@@ -317,9 +317,16 @@ impl ToolboxApp {
     }
 
     fn admin_selected_names(&self) -> Vec<String> {
-        Self::selected_labels(&self.admin_selected, |index| {
-            self.admin_tasks.get(index).map(|task| task.label.clone())
-        })
+        let mut indices: Vec<usize> = self.admin_selected.iter().copied().collect();
+        indices.sort_unstable();
+        indices
+            .into_iter()
+            .filter_map(|index| {
+                self.admin_tasks
+                    .get(index)
+                    .map(|task| recipe_display_label(&task.label).to_owned())
+            })
+            .collect()
     }
 
     fn active_selected_names(&self) -> Vec<String> {
@@ -1002,7 +1009,7 @@ impl ToolboxApp {
                         status_pill(ui, "System up to date", &palette);
                     });
                 });
-                ui.add_space(8.0);
+                ui.add_space(6.0);
                 ui.horizontal(|ui| {
                     let (dot, _) = ui.allocate_exact_size(vec2(8.0, 8.0), Sense::hover());
                     ui.painter()
@@ -1010,7 +1017,7 @@ impl ToolboxApp {
                     ui.add_space(4.0);
                     ui.label(RichText::new(self.ready_line()).color(palette.muted));
                 });
-                ui.add_space(22.0);
+                ui.add_space(20.0);
 
                 let intents = [
                     (
@@ -1300,7 +1307,7 @@ impl ToolboxApp {
 
         let palette = self.palette();
         let count = self.dock_count();
-        let names = truncated_names(&self.dock_names(), 42);
+        let names = truncated_names(&self.dock_names(), 56);
 
         let mut clear = false;
         let mut review = false;
@@ -1314,7 +1321,7 @@ impl ToolboxApp {
                     .fill(palette.surface)
                     .stroke(Stroke::new(1.0_f32, palette.border_strong))
                     .corner_radius(DOCK_RADIUS)
-                    .inner_margin(egui::Margin::symmetric(18, 12))
+                    .inner_margin(egui::Margin::symmetric(20, 14))
                     .shadow(egui::Shadow {
                         offset: [0, 8],
                         blur: 24,
@@ -1324,24 +1331,20 @@ impl ToolboxApp {
                     .show(ui, |ui| {
                         ui.set_min_width(DOCK_MIN_WIDTH);
                         ui.horizontal(|ui| {
-                            ui.spacing_mut().item_spacing.x = 12.0;
+                            ui.spacing_mut().item_spacing.x = 16.0;
                             ui.vertical(|ui| {
-                                ui.horizontal(|ui| {
-                                    ui.spacing_mut().item_spacing.x = 6.0;
-                                    ui.label(
-                                        RichText::new(format!("{count}"))
-                                            .color(palette.accent)
-                                            .strong(),
-                                    );
-                                    ui.label(RichText::new("staged").color(palette.text).strong());
-                                });
+                                ui.label(
+                                    RichText::new(format!("{count} staged"))
+                                        .color(palette.accent)
+                                        .strong(),
+                                );
                                 ui.label(RichText::new(names).color(palette.muted));
                             });
                             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                if cta_button(ui, "Review & Run  →", true, &palette).clicked() {
+                                if cta_button(ui, "Review & Run →", true, &palette).clicked() {
                                     review = true;
                                 }
-                                ui.add_space(8.0);
+                                ui.add_space(10.0);
                                 if ghost_button(ui, "Clear", &palette).clicked() {
                                     clear = true;
                                 }
@@ -2010,15 +2013,15 @@ fn intent_card(
     let (rect, response) = ui.allocate_exact_size(vec2(width, INTENT_HEIGHT), Sense::click());
     paint_surface_card(ui.painter(), rect, response.hovered(), palette);
 
-    let well = Rect::from_min_size(rect.min + vec2(20.0, 18.0), vec2(40.0, 40.0));
+    let well = Rect::from_min_size(rect.min + vec2(18.0, 18.0), vec2(40.0, 40.0));
     ui.painter().rect_filled(well, 12.0, palette.icon_well);
     paint_glyph(ui.painter(), well.shrink(9.0), glyph, palette.accent);
 
     let painter = ui.painter();
-    let text_left = rect.min.x + 20.0;
-    let text_width = (rect.width() - 40.0).max(24.0);
+    let text_left = rect.min.x + 18.0;
+    let text_width = (rect.width() - 36.0).max(24.0);
     painter.text(
-        pos2(text_left, rect.min.y + 72.0),
+        pos2(text_left, rect.min.y + 70.0),
         Align2::LEFT_TOP,
         title,
         FontId::proportional(15.0),
@@ -2032,10 +2035,10 @@ fn intent_card(
     );
     painter
         .with_clip_rect(Rect::from_min_size(
-            pos2(text_left, rect.min.y + 94.0),
-            vec2(text_width, 30.0),
+            pos2(text_left, rect.min.y + 92.0),
+            vec2(text_width, 38.0),
         ))
-        .galley(pos2(text_left, rect.min.y + 94.0), galley, palette.muted);
+        .galley(pos2(text_left, rect.min.y + 92.0), galley, palette.muted);
     response
 }
 
@@ -2056,23 +2059,23 @@ fn metric_tile(
     paint_surface_card(ui.painter(), rect, response.hovered() && clickable, palette);
     let painter = ui.painter();
     painter.text(
-        pos2(rect.min.x + 18.0, rect.min.y + 18.0),
+        pos2(rect.min.x + 16.0, rect.min.y + 14.0),
         Align2::LEFT_TOP,
         label,
         FontId::proportional(11.0),
         palette.muted,
     );
-    let value_pos = pos2(rect.min.x + 18.0, rect.min.y + 40.0);
+    let value_pos = pos2(rect.min.x + 16.0, rect.min.y + 34.0);
     let galley = painter.layout(
         value.to_owned(),
-        FontId::proportional(20.0),
+        FontId::proportional(22.0),
         palette.text,
-        (rect.width() - 36.0).max(24.0),
+        (rect.width() - 32.0).max(24.0),
     );
     painter
         .with_clip_rect(Rect::from_min_size(
             value_pos,
-            vec2((rect.width() - 36.0).max(24.0), 36.0),
+            vec2((rect.width() - 32.0).max(24.0), 34.0),
         ))
         .galley(value_pos, galley, palette.text);
     response
@@ -2230,12 +2233,12 @@ fn paint_warm_chip(painter: &Painter, left_center: Pos2, label: &str, palette: &
 }
 
 fn status_pill(ui: &mut Ui, label: &str, palette: &Palette) {
-    let width = (label.len() as f32 * 7.0 + 20.0).clamp(88.0, 160.0);
-    let (rect, _) = ui.allocate_exact_size(vec2(width, 26.0), Sense::hover());
-    ui.painter().rect_filled(rect, 13.0, palette.surface);
+    let width = (label.len() as f32 * 6.6 + 22.0).clamp(88.0, 168.0);
+    let (rect, _) = ui.allocate_exact_size(vec2(width, 24.0), Sense::hover());
+    ui.painter().rect_filled(rect, 12.0, palette.surface);
     ui.painter().rect_stroke(
         rect,
-        13.0,
+        12.0,
         Stroke::new(1.0_f32, palette.border),
         StrokeKind::Inside,
     );
@@ -2243,7 +2246,7 @@ fn status_pill(ui: &mut Ui, label: &str, palette: &Palette) {
         rect.center(),
         Align2::CENTER_CENTER,
         label,
-        FontId::proportional(11.5),
+        FontId::proportional(11.0),
         palette.muted,
     );
 }
@@ -2333,8 +2336,8 @@ fn cta_button(ui: &mut Ui, label: &str, enabled: bool, palette: &Palette) -> egu
         Button::new(RichText::new(label).color(palette.cta_text).strong())
             .fill(palette.cta_fill)
             .stroke(Stroke::new(1.0_f32, palette.cta_fill))
-            .corner_radius(12.0)
-            .min_size(vec2(132.0, 34.0)),
+            .corner_radius(16.0)
+            .min_size(vec2(148.0, 36.0)),
     )
 }
 
@@ -3052,6 +3055,10 @@ mod tests {
         assert_eq!(RAIL_WIDTH, 68.0);
         assert_eq!(CARD_HEIGHT, 164.0);
         assert_eq!(TITLE_SIZE, 26.0);
+        assert_eq!(INTENT_HEIGHT, 148.0);
+        assert_eq!(GLANCE_HEIGHT, 80.0);
+        assert_eq!(DOCK_MIN_WIDTH, 520.0);
+        assert!(src.contains("{count} staged"));
         assert!(src.contains("fn home_page"));
         assert!(src.contains("fn recipes_page"));
         assert!(!src.contains("fn stub_page"));
@@ -3094,18 +3101,22 @@ mod tests {
 
         app.go_fresh_setup();
         assert_eq!(app.page, Page::Recipes);
-        let selected = app.admin_selected_names();
-        assert!(selected.contains(&"Update System".to_owned()));
-        assert!(selected.contains(&"Fastfetch".to_owned()));
-        assert_eq!(selected.len(), 2);
+        assert_eq!(
+            app.admin_selected_names(),
+            vec!["Update System".to_owned(), "Fastfetch".to_owned()]
+        );
         assert!(app.dock_visible());
 
         app.go_laptop_power();
         let selected = app.admin_selected_names();
-        assert!(selected.contains(&"TLP (Laptops)".to_owned()));
-        assert!(selected.contains(&"Powertop".to_owned()));
-        assert_eq!(selected.len(), 2);
-        assert!(!selected.contains(&"Update System".to_owned()));
+        assert_eq!(
+            selected,
+            vec!["TLP (Laptops)".to_owned(), "Powertop".to_owned()]
+        );
+        assert_eq!(
+            truncated_names(&app.dock_names(), 56),
+            "TLP (Laptops), Powertop"
+        );
     }
 
     #[test]
@@ -3154,7 +3165,7 @@ mod tests {
         assert_eq!(app.modal_count_line(), "This will run 2 recipes.");
         assert_eq!(
             app.review_groups(),
-            vec![("Recipes", vec!["Fastfetch".into(), "Update System".into()])]
+            vec![("Recipes", vec!["Update System".into(), "Fastfetch".into()])]
         );
         assert!(app.other_mode_staged_note().is_none());
 
@@ -3171,6 +3182,12 @@ mod tests {
         assert!(app.admin_selected.is_empty());
         assert!(app.install_selected.contains(&0));
         assert!(!app.dock_visible());
+
+        app.admin_selected.insert(5);
+        assert_eq!(
+            app.admin_selected_names(),
+            vec!["nala (rank mirrors)".to_owned()]
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,6 +110,25 @@ const SEARCH_HEIGHT: f32 = 44.0;
 const DOCK_MIN_WIDTH: f32 = 420.0;
 const DOCK_RADIUS: f32 = 20.0;
 const CONTENT_TWO_COL: f32 = 720.0;
+const INTENT_HEIGHT: f32 = 128.0;
+const GLANCE_HEIGHT: f32 = 96.0;
+const TITLE_SIZE: f32 = 26.0;
+const FRESH_SETUP_LABELS: &[&str] = &["Update System", "Fastfetch"];
+const LAPTOP_POWER_LABELS: &[&str] = &["TLP (Laptops)", "Powertop"];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Glyph {
+    Plus,
+    Bolt,
+    Briefcase,
+    Sliders,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct RecentRun {
+    kind: String,
+    summary: String,
+}
 
 struct ToolboxApp {
     base_dir: PathBuf,
@@ -125,6 +144,11 @@ struct ToolboxApp {
     remove_search: String,
     distro_name: String,
     package_manager: String,
+    host: String,
+    kernel: String,
+    shell: String,
+    de_wm: String,
+    recent_runs: Vec<RecentRun>,
     log: String,
     password: String,
     show_password_modal: bool,
@@ -176,7 +200,7 @@ impl ToolboxApp {
 
         Self {
             base_dir,
-            page: Page::Apps,
+            page: Page::Home,
             apps_mode: AppsMode::Install,
             apps: catalog.apps,
             admin_tasks: admin_tasks(),
@@ -188,6 +212,11 @@ impl ToolboxApp {
             remove_search: String::new(),
             distro_name,
             package_manager,
+            host: command_output("hostname", &[]),
+            kernel: command_output("uname", &["-r"]),
+            shell: env_or_unknown(&["SHELL"]),
+            de_wm: env_or_unknown(&["XDG_CURRENT_DESKTOP", "DESKTOP_SESSION"]),
+            recent_runs: Vec::new(),
             log,
             password: String::new(),
             show_password_modal: false,
@@ -234,8 +263,31 @@ impl ToolboxApp {
         }
     }
 
+    fn dock_can_appear(&self) -> bool {
+        matches!(self.page, Page::Apps | Page::Recipes)
+    }
+
     fn dock_visible(&self) -> bool {
-        self.page == Page::Apps && self.staged_count(self.apps_mode) > 0 && !self.is_running
+        !self.is_running
+            && match self.page {
+                Page::Apps => self.staged_count(self.apps_mode) > 0,
+                Page::Recipes => !self.admin_selected.is_empty(),
+                Page::Home | Page::System => false,
+            }
+    }
+
+    fn dock_count(&self) -> usize {
+        match self.page {
+            Page::Recipes => self.admin_selected.len(),
+            _ => self.staged_count(self.apps_mode),
+        }
+    }
+
+    fn dock_names(&self) -> Vec<String> {
+        match self.page {
+            Page::Recipes => self.admin_selected_names(),
+            _ => self.active_selected_names(),
+        }
     }
 
     fn selection_locked(&self) -> bool {
@@ -260,6 +312,12 @@ impl ToolboxApp {
     fn remove_selected_names(&self) -> Vec<String> {
         Self::selected_labels(&self.remove_selected, |index| {
             self.remove_apps.get(index).map(|app| app.label.clone())
+        })
+    }
+
+    fn admin_selected_names(&self) -> Vec<String> {
+        Self::selected_labels(&self.admin_selected, |index| {
+            self.admin_tasks.get(index).map(|task| task.label.clone())
         })
     }
 
@@ -330,12 +388,13 @@ impl ToolboxApp {
     fn selected_tasks(&self) -> Result<Vec<Task>, Vec<String>> {
         let mut tasks = Vec::new();
         let mut errors = Vec::new();
-        match self.apps_mode {
-            AppsMode::Install => self.push_install_tasks(&mut tasks, &mut errors),
-            AppsMode::Remove => self.push_remove_tasks(&mut tasks, &mut errors),
-        }
-        if self.page == Page::Recipes {
-            self.push_admin_tasks(&mut tasks, &mut errors);
+        match self.page {
+            Page::Recipes => self.push_admin_tasks(&mut tasks, &mut errors),
+            Page::Apps => match self.apps_mode {
+                AppsMode::Install => self.push_install_tasks(&mut tasks, &mut errors),
+                AppsMode::Remove => self.push_remove_tasks(&mut tasks, &mut errors),
+            },
+            Page::Home | Page::System => {}
         }
         if errors.is_empty() {
             Ok(tasks)
@@ -356,6 +415,42 @@ impl ToolboxApp {
             AppsMode::Install => self.install_selected.clear(),
             AppsMode::Remove => self.remove_selected.clear(),
         }
+    }
+
+    fn clear_dock_selections(&mut self) {
+        match self.page {
+            Page::Recipes => self.admin_selected.clear(),
+            Page::Apps => self.clear_active_mode_selections(),
+            Page::Home | Page::System => {}
+        }
+    }
+
+    fn preselect_admin_labels(&mut self, labels: &[&str]) {
+        self.admin_selected.clear();
+        for (index, task) in self.admin_tasks.iter().enumerate() {
+            if labels.contains(&task.label.as_str()) {
+                self.admin_selected.insert(index);
+            }
+        }
+    }
+
+    fn go_install_apps(&mut self) {
+        self.apps_mode = AppsMode::Install;
+        self.switch_page(Page::Apps);
+    }
+
+    fn go_fresh_setup(&mut self) {
+        self.preselect_admin_labels(FRESH_SETUP_LABELS);
+        self.switch_page(Page::Recipes);
+    }
+
+    fn go_laptop_power(&mut self) {
+        self.preselect_admin_labels(LAPTOP_POWER_LABELS);
+        self.switch_page(Page::Recipes);
+    }
+
+    fn go_system(&mut self) {
+        self.switch_page(Page::System);
     }
 
     fn app_matches_filter(&self, entry: &AppEntry) -> bool {
@@ -525,6 +620,7 @@ impl ToolboxApp {
         }
 
         if done {
+            self.record_recent_run();
             self.is_running = false;
             zeroize_string(&mut self.password);
             self.tx = None;
@@ -532,6 +628,28 @@ impl ToolboxApp {
             self.log.push_str("\n\n[DONE] All tasks finished.");
             self.log_revision = self.log_revision.saturating_add(1);
         }
+    }
+
+    fn record_recent_run(&mut self) {
+        let (kind, names) = match self.page {
+            Page::Recipes => ("Recipe", self.admin_selected_names()),
+            Page::Apps if self.apps_mode == AppsMode::Remove => {
+                ("Remove", self.remove_selected_names())
+            }
+            Page::Apps => ("Install", self.install_selected_names()),
+            Page::Home | Page::System => return,
+        };
+        if names.is_empty() {
+            return;
+        }
+        self.recent_runs.insert(
+            0,
+            RecentRun {
+                kind: kind.to_owned(),
+                summary: truncated_names(&names, 48),
+            },
+        );
+        self.recent_runs.truncate(8);
     }
 
     fn rail(&mut self, ui: &mut Ui) {
@@ -576,7 +694,7 @@ impl ToolboxApp {
         ui.horizontal(|ui| {
             ui.label(
                 RichText::new("Apps")
-                    .font(FontId::proportional(26.0))
+                    .font(FontId::proportional(TITLE_SIZE))
                     .color(palette.text)
                     .strong(),
             );
@@ -812,54 +930,309 @@ impl ToolboxApp {
         None
     }
 
-    fn stub_page(&self, ui: &mut Ui, title: &str, body: &str) {
-        let palette = self.palette();
-        ui.label(
-            RichText::new(title)
-                .font(FontId::proportional(26.0))
-                .color(palette.text)
-                .strong(),
-        );
-        ui.add_space(12.0);
-        ui.label(RichText::new(body).color(palette.muted));
+    fn ready_line(&self) -> String {
+        format!(
+            "{} is ready · package manager {}",
+            self.distro_name, self.package_manager
+        )
     }
 
-    fn system_info_page(&mut self, ui: &mut Ui) {
-        let rows = [
+    fn glance_metrics(&self) -> [(&'static str, String); 4] {
+        [
             ("OS", self.distro_name.clone()),
-            ("Host", command_output("hostname", &[])),
-            ("Kernel", command_output("uname", &["-r"])),
+            ("Kernel", self.kernel.clone()),
             ("Uptime", uptime()),
-            ("Shell", env_or_unknown(&["SHELL"])),
-            (
-                "DE/WM",
-                env_or_unknown(&["XDG_CURRENT_DESKTOP", "DESKTOP_SESSION"]),
-            ),
+            ("PM", self.package_manager.clone()),
+        ]
+    }
+
+    fn system_detail_rows(&self) -> [(&'static str, String); 8] {
+        [
+            ("OS", self.distro_name.clone()),
+            ("Host", self.host.clone()),
+            ("Kernel", self.kernel.clone()),
+            ("Uptime", uptime()),
+            ("Shell", self.shell.clone()),
+            ("DE/WM", self.de_wm.clone()),
             ("Package Manager", self.package_manager.clone()),
             ("App Directory", self.base_dir.display().to_string()),
-        ];
+        ]
+    }
 
+    fn copy_system_details(&self, ctx: &Context) {
+        let text = self
+            .system_detail_rows()
+            .into_iter()
+            .map(|(label, value)| format!("{label}: {value}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        ctx.copy_text(text);
+    }
+
+    fn recipe_groups(&self) -> Vec<(String, Vec<usize>)> {
+        let mut groups: Vec<(String, Vec<usize>)> = Vec::new();
+        for (index, task) in self.admin_tasks.iter().enumerate() {
+            if let Some((_, items)) = groups
+                .iter_mut()
+                .find(|(category, _)| category == &task.category)
+            {
+                items.push(index);
+            } else {
+                groups.push((task.category.clone(), vec![index]));
+            }
+        }
+        groups
+    }
+
+    fn home_page(&mut self, ui: &mut Ui) {
         let palette = self.palette();
-        ui.label(
-            RichText::new("System")
-                .font(FontId::proportional(26.0))
-                .color(palette.text)
-                .strong(),
-        );
-        ui.add_space(16.0);
-        Grid::new("system_info_grid")
-            .num_columns(2)
-            .spacing(Vec2::new(28.0, 14.0))
+        ScrollArea::vertical()
+            .id_salt("home_page")
+            .auto_shrink([false, false])
             .show(ui, |ui| {
-                for (label, value) in rows {
-                    ui.label(RichText::new(label).color(palette.muted).strong());
-                    ui.label(RichText::new(value).color(palette.text));
-                    ui.end_row();
+                ui.label(
+                    RichText::new(greeting())
+                        .font(FontId::proportional(TITLE_SIZE))
+                        .color(palette.text)
+                        .strong(),
+                );
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    let (dot, _) = ui.allocate_exact_size(vec2(8.0, 8.0), Sense::hover());
+                    ui.painter()
+                        .circle_filled(dot.center(), 3.5, palette.accent);
+                    ui.add_space(4.0);
+                    ui.label(RichText::new(self.ready_line()).color(palette.muted));
+                });
+                ui.add_space(22.0);
+
+                let intents = [
+                    (
+                        Glyph::Plus,
+                        "Install apps",
+                        "Browse the catalog and stage what you need.",
+                    ),
+                    (
+                        Glyph::Bolt,
+                        "Fresh setup",
+                        "One recipe for a new distro hop — essentials ready.",
+                    ),
+                    (
+                        Glyph::Briefcase,
+                        "Laptop power",
+                        "TLP + Powertop tuned so the battery lasts.",
+                    ),
+                ];
+                let columns = intent_columns(ui);
+                let width = tile_width(ui, columns);
+                let mut chosen = None;
+                for (row_index, row) in intents.chunks(columns).enumerate() {
+                    if row_index > 0 {
+                        ui.add_space(CARD_GAP);
+                    }
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = CARD_GAP;
+                        for (offset, (glyph, title, body)) in row.iter().enumerate() {
+                            let index = row_index * columns + offset;
+                            if intent_card(ui, width, *glyph, title, body, &palette).clicked() {
+                                chosen = Some(index);
+                            }
+                        }
+                    });
+                }
+                ui.add_space(CARD_GAP);
+                match chosen {
+                    Some(0) => self.go_install_apps(),
+                    Some(1) => self.go_fresh_setup(),
+                    Some(2) => self.go_laptop_power(),
+                    _ => {}
+                }
+
+                ui.add_space(8.0);
+                section_eyebrow(ui, "System glance", &palette);
+                ui.add_space(10.0);
+                let metrics = self.glance_metrics();
+                let glance_cols = glance_columns(ui);
+                let glance_width = tile_width(ui, glance_cols);
+                let mut open_system = false;
+                for start in (0..metrics.len()).step_by(glance_cols) {
+                    let end = (start + glance_cols).min(metrics.len());
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = CARD_GAP;
+                        for item in &metrics[start..end] {
+                            if metric_tile(ui, glance_width, item.0, &item.1, true, &palette)
+                                .clicked()
+                            {
+                                open_system = true;
+                            }
+                        }
+                    });
+                    ui.add_space(CARD_GAP);
+                }
+                if open_system {
+                    self.go_system();
+                }
+
+                ui.add_space(8.0);
+                section_eyebrow(ui, "Recent runs", &palette);
+                ui.add_space(10.0);
+                self.recent_runs_card(ui, &palette);
+            });
+    }
+
+    fn recent_runs_card(&self, ui: &mut Ui, palette: &Palette) {
+        Frame::new()
+            .fill(palette.surface)
+            .stroke(Stroke::new(1.0_f32, palette.border))
+            .corner_radius(CARD_RADIUS)
+            .inner_margin(egui::Margin::symmetric(18, 16))
+            .show(ui, |ui| {
+                ui.set_width(ui.available_width());
+                if self.recent_runs.is_empty() {
+                    ui.label(
+                        RichText::new("No runs yet — stage apps or a recipe to get started.")
+                            .color(palette.muted),
+                    );
+                    return;
+                }
+                for (index, run) in self.recent_runs.iter().enumerate() {
+                    if index > 0 {
+                        ui.add_space(10.0);
+                    }
+                    ui.horizontal(|ui| {
+                        paint_kind_chip(ui, &run.kind, palette);
+                        ui.add_space(8.0);
+                        ui.label(RichText::new(&run.summary).color(palette.text));
+                    });
                 }
             });
     }
 
+    fn recipes_page(&mut self, ui: &mut Ui) {
+        let palette = self.palette();
+        ui.label(
+            RichText::new("Recipes")
+                .font(FontId::proportional(TITLE_SIZE))
+                .color(palette.text)
+                .strong(),
+        );
+        ui.add_space(6.0);
+        ui.label(RichText::new("One-click admin playbooks for this machine.").color(palette.muted));
+        ui.add_space(16.0);
+
+        let groups = self.recipe_groups();
+        ScrollArea::vertical()
+            .id_salt("recipes_cards")
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                for (group_index, (category, indices)) in groups.iter().enumerate() {
+                    if group_index > 0 {
+                        ui.add_space(8.0);
+                    }
+                    section_eyebrow(ui, category, &palette);
+                    ui.add_space(10.0);
+                    let columns = card_columns(ui);
+                    self.card_rows(ui, columns, indices.len(), |app, ui, index, width| {
+                        app.recipe_tile(ui, indices[index], width);
+                    });
+                }
+            });
+    }
+
+    fn recipe_tile(&mut self, ui: &mut Ui, index: usize, width: f32) {
+        let task = &self.admin_tasks[index];
+        let label = task.label.clone();
+        let category = task.category.clone();
+        let selected = self.admin_selected.contains(&index);
+        let palette = self.palette();
+        let locked = self.selection_locked();
+        if recipe_card(ui, width, selected, &label, &category, &palette).clicked() && !locked {
+            if selected {
+                self.admin_selected.remove(&index);
+            } else {
+                self.admin_selected.insert(index);
+            }
+        }
+    }
+
+    fn system_info_page(&mut self, ui: &mut Ui) {
+        let palette = self.palette();
+        let metrics = self.glance_metrics();
+        let rows = self.system_detail_rows();
+        ScrollArea::vertical()
+            .id_salt("system_page")
+            .auto_shrink([false, false])
+            .show(ui, |ui| {
+                ui.label(
+                    RichText::new(&self.distro_name)
+                        .font(FontId::proportional(TITLE_SIZE))
+                        .color(palette.text)
+                        .strong(),
+                );
+                ui.add_space(6.0);
+                ui.label(
+                    RichText::new(format!(
+                        "{} · {} · {}",
+                        self.kernel,
+                        self.package_manager,
+                        uptime()
+                    ))
+                    .color(palette.muted),
+                );
+                ui.add_space(20.0);
+
+                let glance_cols = glance_columns(ui);
+                let glance_width = tile_width(ui, glance_cols);
+                for start in (0..metrics.len()).step_by(glance_cols) {
+                    let end = (start + glance_cols).min(metrics.len());
+                    ui.horizontal(|ui| {
+                        ui.spacing_mut().item_spacing.x = CARD_GAP;
+                        for item in &metrics[start..end] {
+                            metric_tile(ui, glance_width, item.0, &item.1, false, &palette);
+                        }
+                    });
+                    ui.add_space(CARD_GAP);
+                }
+
+                ui.add_space(8.0);
+                Frame::new()
+                    .fill(palette.surface)
+                    .stroke(Stroke::new(1.0_f32, palette.border))
+                    .corner_radius(CARD_RADIUS)
+                    .inner_margin(egui::Margin::symmetric(18, 16))
+                    .show(ui, |ui| {
+                        ui.horizontal(|ui| {
+                            ui.label(RichText::new("Details").color(palette.text).strong());
+                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                                if ghost_button(ui, "Copy all", &palette).clicked() {
+                                    self.copy_system_details(ui.ctx());
+                                }
+                            });
+                        });
+                        ui.add_space(12.0);
+                        Grid::new("system_info_grid")
+                            .num_columns(2)
+                            .spacing(Vec2::new(28.0, 12.0))
+                            .show(ui, |ui| {
+                                for (label, value) in &rows {
+                                    ui.label(RichText::new(*label).color(palette.muted));
+                                    ui.label(RichText::new(value).color(palette.text));
+                                    ui.end_row();
+                                }
+                            });
+                    });
+            });
+    }
+
     fn modal_count_line(&self) -> String {
+        if self.page == Page::Recipes {
+            let n = self.admin_selected.len();
+            return if n == 1 {
+                "This will run 1 recipe.".to_owned()
+            } else {
+                format!("This will run {n} recipes.")
+            };
+        }
         let n = self.staged_count(self.apps_mode);
         match self.apps_mode {
             AppsMode::Install if n == 1 => "This will install 1 app.".to_owned(),
@@ -870,6 +1243,14 @@ impl ToolboxApp {
     }
 
     fn review_groups(&self) -> Vec<(&'static str, Vec<String>)> {
+        if self.page == Page::Recipes {
+            let recipes = self.admin_selected_names();
+            return if recipes.is_empty() {
+                Vec::new()
+            } else {
+                vec![("Recipes", recipes)]
+            };
+        }
         let install = if self.apps_mode == AppsMode::Install {
             self.install_selected_names()
         } else {
@@ -891,6 +1272,9 @@ impl ToolboxApp {
     }
 
     fn other_mode_staged_note(&self) -> Option<String> {
+        if self.page != Page::Apps {
+            return None;
+        }
         match self.apps_mode {
             AppsMode::Install if !self.remove_selected.is_empty() => Some(format!(
                 "{} also staged in Remove. Switch to Remove to run those.",
@@ -910,8 +1294,8 @@ impl ToolboxApp {
         }
 
         let palette = self.palette();
-        let count = self.staged_count(self.apps_mode);
-        let names = truncated_names(&self.active_selected_names(), 42);
+        let count = self.dock_count();
+        let names = truncated_names(&self.dock_names(), 42);
 
         let mut clear = false;
         let mut review = false;
@@ -957,7 +1341,7 @@ impl ToolboxApp {
             });
 
         if clear {
-            self.clear_active_mode_selections();
+            self.clear_dock_selections();
         }
         if review {
             self.show_password_modal = true;
@@ -1195,20 +1579,12 @@ impl eframe::App for ToolboxApp {
                 left: 40,
                 right: 40,
                 top: 28,
-                bottom: 120,
+                bottom: if self.dock_can_appear() { 120 } else { 40 },
             }))
             .show_inside(ui, |ui| match self.page {
-                Page::Home => self.stub_page(
-                    ui,
-                    "Home",
-                    "Home is coming in a later release. Use Apps to install or remove software.",
-                ),
+                Page::Home => self.home_page(ui),
                 Page::Apps => self.apps_page(ui),
-                Page::Recipes => self.stub_page(
-                    ui,
-                    "Recipes",
-                    "Recipes is coming in a later release. Admin task presets will live here.",
-                ),
+                Page::Recipes => self.recipes_page(ui),
                 Page::System => self.system_info_page(ui),
             });
 
@@ -1566,9 +1942,342 @@ fn card_columns(ui: &Ui) -> usize {
     }
 }
 
+fn intent_columns(ui: &Ui) -> usize {
+    if ui.available_width() < 560.0 {
+        1
+    } else if ui.available_width() < CONTENT_TWO_COL {
+        2
+    } else {
+        3
+    }
+}
+
+fn glance_columns(ui: &Ui) -> usize {
+    if ui.available_width() < 640.0 { 2 } else { 4 }
+}
+
 fn tile_width(ui: &Ui, columns: usize) -> f32 {
     let columns = columns.max(1) as f32;
     ((ui.available_width() - CARD_GAP * (columns - 1.0)) / columns).max(220.0)
+}
+
+fn section_eyebrow(ui: &mut Ui, label: &str, palette: &Palette) {
+    ui.label(
+        RichText::new(label.to_ascii_uppercase())
+            .font(FontId::proportional(11.0))
+            .color(palette.muted),
+    );
+}
+
+fn greeting() -> &'static str {
+    greeting_for_hour(local_hour())
+}
+
+fn local_hour() -> u32 {
+    command_output("date", &["+%H"])
+        .parse()
+        .ok()
+        .filter(|hour| *hour < 24)
+        .unwrap_or(18)
+}
+
+fn greeting_for_hour(hour: u32) -> &'static str {
+    match hour {
+        5..=11 => "Good morning",
+        12..=16 => "Good afternoon",
+        _ => "Good evening",
+    }
+}
+
+fn intent_card(
+    ui: &mut Ui,
+    width: f32,
+    glyph: Glyph,
+    title: &str,
+    body: &str,
+    palette: &Palette,
+) -> egui::Response {
+    let (rect, response) = ui.allocate_exact_size(vec2(width, INTENT_HEIGHT), Sense::click());
+    paint_surface_card(ui.painter(), rect, response.hovered(), palette);
+
+    let well = Rect::from_min_size(rect.min + vec2(16.0, 16.0), vec2(36.0, 36.0));
+    ui.painter().rect_filled(well, 10.0, palette.icon_well);
+    paint_glyph(ui.painter(), well.shrink(8.0), glyph, palette.accent);
+
+    let painter = ui.painter();
+    let text_left = rect.min.x + 16.0;
+    let text_width = (rect.width() - 32.0).max(24.0);
+    painter.text(
+        pos2(text_left, rect.min.y + 68.0),
+        Align2::LEFT_CENTER,
+        title,
+        FontId::proportional(15.0),
+        palette.text,
+    );
+    let galley = painter.layout(
+        body.to_owned(),
+        FontId::proportional(12.0),
+        palette.muted,
+        text_width,
+    );
+    painter
+        .with_clip_rect(Rect::from_min_size(
+            pos2(text_left, rect.min.y + 82.0),
+            vec2(text_width, 34.0),
+        ))
+        .galley(pos2(text_left, rect.min.y + 82.0), galley, palette.muted);
+    response
+}
+
+fn metric_tile(
+    ui: &mut Ui,
+    width: f32,
+    label: &str,
+    value: &str,
+    clickable: bool,
+    palette: &Palette,
+) -> egui::Response {
+    let sense = if clickable {
+        Sense::click()
+    } else {
+        Sense::hover()
+    };
+    let (rect, response) = ui.allocate_exact_size(vec2(width, GLANCE_HEIGHT), sense);
+    paint_surface_card(ui.painter(), rect, response.hovered() && clickable, palette);
+    let painter = ui.painter();
+    painter.text(
+        pos2(rect.min.x + 16.0, rect.min.y + 22.0),
+        Align2::LEFT_CENTER,
+        label,
+        FontId::proportional(11.0),
+        palette.muted,
+    );
+    painter.text(
+        pos2(rect.min.x + 16.0, rect.min.y + 48.0),
+        Align2::LEFT_CENTER,
+        value,
+        FontId::proportional(20.0),
+        palette.text,
+    );
+    let bar = Rect::from_min_size(
+        pos2(rect.min.x + 16.0, rect.bottom() - 18.0),
+        vec2(36.0, 3.0),
+    );
+    painter.rect_filled(bar, 2.0, palette.accent);
+    response
+}
+
+fn paint_surface_card(painter: &Painter, rect: Rect, hovered: bool, palette: &Palette) {
+    painter.rect_filled(
+        rect,
+        CARD_RADIUS,
+        if hovered {
+            palette.surface_hover
+        } else {
+            palette.surface
+        },
+    );
+    painter.rect_stroke(
+        rect,
+        CARD_RADIUS,
+        Stroke::new(1.0_f32, palette.border),
+        StrokeKind::Inside,
+    );
+}
+
+fn recipe_card(
+    ui: &mut Ui,
+    width: f32,
+    selected: bool,
+    label: &str,
+    category: &str,
+    palette: &Palette,
+) -> egui::Response {
+    let (rect, response) = ui.allocate_exact_size(vec2(width, CARD_HEIGHT), Sense::click());
+    paint_card_background(ui.painter(), rect, selected, palette);
+
+    let well = Rect::from_min_size(rect.min + vec2(16.0, 16.0), vec2(CARD_ICON, CARD_ICON));
+    ui.painter().rect_filled(well, 12.0, palette.icon_well);
+    paint_glyph(
+        ui.painter(),
+        well.shrink(10.0),
+        recipe_glyph(category),
+        palette.accent,
+    );
+
+    let check_rect = Rect::from_min_size(
+        pos2(rect.right() - 16.0 - CHECK_SIZE, rect.min.y + 16.0),
+        vec2(CHECK_SIZE, CHECK_SIZE),
+    );
+    paint_check(ui.painter(), check_rect, selected, palette);
+
+    let text_left = rect.min.x + 16.0;
+    let text_width = (rect.width() - 32.0).max(24.0);
+    let painter = ui.painter();
+    painter.text(
+        pos2(text_left, rect.min.y + 72.0),
+        Align2::LEFT_CENTER,
+        label,
+        FontId::proportional(14.0),
+        palette.text,
+    );
+
+    let galley = painter.layout(
+        recipe_promise(label).to_owned(),
+        FontId::proportional(12.0),
+        palette.muted,
+        text_width,
+    );
+    painter
+        .with_clip_rect(Rect::from_min_size(
+            pos2(text_left, rect.min.y + 86.0),
+            vec2(text_width, 28.0),
+        ))
+        .galley(pos2(text_left, rect.min.y + 86.0), galley, palette.muted);
+
+    if let Some(chip) = recipe_chip(label) {
+        paint_warm_chip(
+            painter,
+            pos2(text_left + 4.0, rect.bottom() - 22.0),
+            chip,
+            palette,
+        );
+    }
+
+    response
+}
+
+fn recipe_glyph(category: &str) -> Glyph {
+    if category == "Power Management" {
+        Glyph::Bolt
+    } else {
+        Glyph::Sliders
+    }
+}
+
+fn recipe_promise(label: &str) -> &'static str {
+    match label {
+        "Enable Bluetooth" => "Turn Bluetooth on for this machine.",
+        "Disable Bluetooth" => "Turn Bluetooth off to save power.",
+        "TLP (Laptops)" => "Tune laptop power so the battery lasts.",
+        "Powertop" => "Diagnose and cut background power waste.",
+        "Update System" => "Bring packages on this machine up to date.",
+        "nala (rank mirrors) - Debian only" => "Rank Debian mirrors for faster apt.",
+        "Stacer" => "Lightweight Linux system optimizer.",
+        "SWAP Fix" => "Lower swappiness so resume stays snappy.",
+        "Fastfetch" => "Show a clean system summary in the terminal.",
+        _ => "Admin playbook for this machine.",
+    }
+}
+
+fn recipe_chip(label: &str) -> Option<&'static str> {
+    match label {
+        "Update System" | "SWAP Fix" => Some("Caution"),
+        other if other.contains("Debian only") => Some("Debian only"),
+        _ => None,
+    }
+}
+
+fn paint_warm_chip(painter: &Painter, left_center: Pos2, label: &str, palette: &Palette) {
+    let width = (label.len() as f32 * 7.2 + 16.0).clamp(56.0, 140.0);
+    let rect = Rect::from_center_size(
+        pos2(left_center.x + width / 2.0, left_center.y),
+        vec2(width, 20.0),
+    );
+    painter.rect_filled(rect, 6.0, palette.caution);
+    painter.text(
+        rect.center(),
+        Align2::CENTER_CENTER,
+        label,
+        FontId::proportional(10.5),
+        palette.caution_on,
+    );
+}
+
+fn paint_kind_chip(ui: &mut Ui, kind: &str, palette: &Palette) {
+    let width = (kind.len() as f32 * 7.2 + 16.0).clamp(56.0, 100.0);
+    let (rect, _) = ui.allocate_exact_size(vec2(width, 22.0), Sense::hover());
+    let (fill, text) = match kind {
+        "Recipe" => (palette.caution, palette.caution_on),
+        _ => (palette.elevated, palette.accent),
+    };
+    ui.painter().rect_filled(rect, 6.0, fill);
+    ui.painter().text(
+        rect.center(),
+        Align2::CENTER_CENTER,
+        kind,
+        FontId::proportional(11.0),
+        text,
+    );
+}
+
+fn paint_glyph(painter: &Painter, rect: Rect, glyph: Glyph, color: Color32) {
+    let stroke = Stroke::new(1.8_f32, color);
+    match glyph {
+        Glyph::Plus => {
+            painter.line_segment(
+                [
+                    pos2(rect.center().x, rect.top()),
+                    pos2(rect.center().x, rect.bottom()),
+                ],
+                stroke,
+            );
+            painter.line_segment(
+                [
+                    pos2(rect.left(), rect.center().y),
+                    pos2(rect.right(), rect.center().y),
+                ],
+                stroke,
+            );
+        }
+        Glyph::Bolt => {
+            painter.line_segment(
+                [
+                    pos2(rect.center().x + 3.0, rect.top()),
+                    pos2(rect.left() + 2.0, rect.center().y + 1.0),
+                ],
+                stroke,
+            );
+            painter.line_segment(
+                [
+                    pos2(rect.left() + 2.0, rect.center().y + 1.0),
+                    pos2(rect.center().x + 1.0, rect.center().y + 1.0),
+                ],
+                stroke,
+            );
+            painter.line_segment(
+                [
+                    pos2(rect.center().x + 1.0, rect.center().y + 1.0),
+                    pos2(rect.center().x - 3.0, rect.bottom()),
+                ],
+                stroke,
+            );
+        }
+        Glyph::Briefcase => {
+            painter.rect_stroke(
+                Rect::from_min_max(
+                    pos2(rect.left() + 1.0, rect.center().y - 2.0),
+                    pos2(rect.right() - 1.0, rect.bottom() - 1.0),
+                ),
+                2.0,
+                stroke,
+                StrokeKind::Inside,
+            );
+            painter.rect_stroke(
+                Rect::from_center_size(pos2(rect.center().x, rect.top() + 4.0), vec2(8.0, 6.0)),
+                1.5,
+                stroke,
+                StrokeKind::Inside,
+            );
+        }
+        Glyph::Sliders => {
+            for (y_off, knob) in [(0.22, 0.65), (0.50, 0.35), (0.78, 0.55)] {
+                let y = rect.top() + rect.height() * y_off;
+                painter.line_segment([pos2(rect.left(), y), pos2(rect.right(), y)], stroke);
+                painter.circle_filled(pos2(rect.left() + rect.width() * knob, y), 2.6, color);
+            }
+        }
+    }
 }
 
 fn cta_button(ui: &mut Ui, label: &str, enabled: bool, palette: &Palette) -> egui::Response {
@@ -1583,7 +2292,8 @@ fn cta_button(ui: &mut Ui, label: &str, enabled: bool, palette: &Palette) -> egu
 }
 
 fn ghost_button(ui: &mut Ui, label: &str, palette: &Palette) -> egui::Response {
-    let (rect, response) = ui.allocate_exact_size(vec2(64.0, 32.0), Sense::click());
+    let width = (label.len() as f32 * 7.4 + 20.0).clamp(64.0, 120.0);
+    let (rect, response) = ui.allocate_exact_size(vec2(width, 32.0), Sense::click());
     if response.hovered() {
         ui.painter().rect_filled(rect, 8.0, palette.surface_hover);
     }
@@ -1967,6 +2677,11 @@ mod tests {
             remove_search: String::new(),
             distro_name: "Debian".to_owned(),
             package_manager: "apt-get".to_owned(),
+            host: "testhost".to_owned(),
+            kernel: "6.12.0-test".to_owned(),
+            shell: "/bin/bash".to_owned(),
+            de_wm: "sway".to_owned(),
+            recent_runs: Vec::new(),
             log: String::new(),
             password: String::new(),
             show_password_modal: false,
@@ -2091,6 +2806,7 @@ mod tests {
             .expect("review_groups body");
         assert!(groups.contains("\"Install\""));
         assert!(groups.contains("\"Remove\""));
+        assert!(groups.contains("\"Recipes\""));
         let modal = src
             .split("fn sudo_modal")
             .nth(1)
@@ -2288,6 +3004,12 @@ mod tests {
         assert!(src.contains("run_dock"));
         assert_eq!(RAIL_WIDTH, 68.0);
         assert_eq!(CARD_HEIGHT, 164.0);
+        assert_eq!(TITLE_SIZE, 26.0);
+        assert!(src.contains("fn home_page"));
+        assert!(src.contains("fn recipes_page"));
+        assert!(!src.contains("fn stub_page"));
+        assert!(!src.contains("Home is coming"));
+        assert!(!src.contains("Recipes is coming"));
     }
 
     #[test]
@@ -2312,5 +3034,204 @@ mod tests {
         for retired in ["#E9FC12", "E9FC12", "#1A365D", "1A365D", "#CDEDFE"] {
             assert!(!src.contains(retired), "{retired}");
         }
+    }
+
+    #[test]
+    fn home_intents_navigate_and_preselect_recipes() {
+        let mut app = test_app();
+        app.admin_tasks = admin_tasks();
+
+        app.go_install_apps();
+        assert_eq!(app.page, Page::Apps);
+        assert_eq!(app.apps_mode, AppsMode::Install);
+
+        app.go_fresh_setup();
+        assert_eq!(app.page, Page::Recipes);
+        let selected = app.admin_selected_names();
+        assert!(selected.contains(&"Update System".to_owned()));
+        assert!(selected.contains(&"Fastfetch".to_owned()));
+        assert_eq!(selected.len(), 2);
+        assert!(app.dock_visible());
+
+        app.go_laptop_power();
+        let selected = app.admin_selected_names();
+        assert!(selected.contains(&"TLP (Laptops)".to_owned()));
+        assert!(selected.contains(&"Powertop".to_owned()));
+        assert_eq!(selected.len(), 2);
+        assert!(!selected.contains(&"Update System".to_owned()));
+    }
+
+    #[test]
+    fn home_glance_uses_live_fields_not_fake_cpu() {
+        let app = test_app();
+        let metrics = app.glance_metrics();
+        assert_eq!(metrics[0].0, "OS");
+        assert_eq!(metrics[1].0, "Kernel");
+        assert_eq!(metrics[2].0, "Uptime");
+        assert_eq!(metrics[3].0, "PM");
+        assert_eq!(metrics[0].1, "Debian");
+        assert_eq!(metrics[1].1, "6.12.0-test");
+        assert_eq!(metrics[3].1, "apt-get");
+        let src = production_main();
+        assert!(src.contains("SYSTEM GLANCE") || src.contains("System glance"));
+        assert!(!src.contains("\"CPU\""));
+        assert!(!src.contains("No runs yet") || src.contains("stage apps or a recipe"));
+        assert!(src.contains("No runs yet — stage apps or a recipe to get started."));
+        let home = src
+            .split("fn home_page")
+            .nth(1)
+            .and_then(|rest| rest.split("fn recent_runs_card").next())
+            .expect("home_page");
+        assert!(!home.contains("checkbox"));
+        assert!(home.contains("go_install_apps"));
+        assert!(home.contains("go_fresh_setup"));
+        assert!(home.contains("go_laptop_power"));
+        assert!(home.contains("go_system"));
+    }
+
+    #[test]
+    fn recipes_stage_into_run_dock_and_review_group() {
+        let mut app = test_app();
+        app.admin_tasks = admin_tasks();
+        app.install_selected.insert(0);
+        app.page = Page::Recipes;
+        app.admin_selected.insert(4);
+        app.admin_selected.insert(8);
+
+        assert!(app.dock_visible());
+        assert_eq!(app.dock_count(), 2);
+        assert_eq!(app.modal_count_line(), "This will run 2 recipes.");
+        assert_eq!(
+            app.review_groups(),
+            vec![("Recipes", vec!["Fastfetch".into(), "Update System".into()])]
+        );
+        assert!(app.other_mode_staged_note().is_none());
+
+        let tasks = app.selected_tasks().expect("recipe tasks");
+        assert_eq!(tasks.len(), 2);
+        assert!(
+            tasks
+                .iter()
+                .all(|task| task.description.starts_with("Running "))
+        );
+        assert!(app.install_selected.contains(&0));
+
+        app.clear_dock_selections();
+        assert!(app.admin_selected.is_empty());
+        assert!(app.install_selected.contains(&0));
+        assert!(!app.dock_visible());
+    }
+
+    #[test]
+    fn recipes_dock_hides_while_running_and_locks_selection() {
+        let mut app = test_app();
+        app.page = Page::Recipes;
+        app.admin_selected.insert(0);
+        assert!(app.dock_visible());
+        app.is_running = true;
+        assert!(!app.dock_visible());
+        assert!(app.selection_locked());
+        assert!(app.admin_selected.contains(&0));
+        app.switch_page(Page::Home);
+        app.is_running = false;
+        assert!(!app.dock_visible());
+        assert!(app.admin_selected.contains(&0));
+    }
+
+    #[test]
+    fn every_admin_task_has_a_promise_and_optional_chip() {
+        for task in admin_tasks() {
+            let promise = recipe_promise(&task.label);
+            assert_ne!(
+                promise, "Admin playbook for this machine.",
+                "{}",
+                task.label
+            );
+            match task.label.as_str() {
+                "Update System" | "SWAP Fix" => {
+                    assert_eq!(recipe_chip(&task.label), Some("Caution"));
+                }
+                other if other.contains("Debian only") => {
+                    assert_eq!(recipe_chip(&task.label), Some("Debian only"));
+                }
+                _ => assert_eq!(recipe_chip(&task.label), None),
+            }
+        }
+        assert_eq!(admin_tasks().len(), 9);
+        let groups = {
+            let app = {
+                let mut app = test_app();
+                app.admin_tasks = admin_tasks();
+                app
+            };
+            app.recipe_groups()
+        };
+        assert_eq!(
+            groups
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>(),
+            ["Power Management", "System"]
+        );
+    }
+
+    #[test]
+    fn system_detail_keeps_live_fields_and_copy_all() {
+        let app = test_app();
+        let rows = app.system_detail_rows();
+        assert_eq!(rows[0].0, "OS");
+        assert_eq!(rows[1].0, "Host");
+        assert_eq!(rows[2].0, "Kernel");
+        assert_eq!(rows[3].0, "Uptime");
+        assert_eq!(rows[4].0, "Shell");
+        assert_eq!(rows[5].0, "DE/WM");
+        assert_eq!(rows[6].0, "Package Manager");
+        assert_eq!(rows[7].0, "App Directory");
+        assert_eq!(rows[1].1, "testhost");
+        assert_eq!(rows[4].1, "/bin/bash");
+        let src = production_main();
+        let system = src
+            .split("fn system_info_page")
+            .nth(1)
+            .and_then(|rest| rest.split("fn modal_count_line").next())
+            .expect("system_info_page");
+        assert!(system.contains("Copy all"));
+        assert!(system.contains("copy_system_details"));
+        assert!(!system.contains("command_output"));
+        assert_eq!(greeting_for_hour(7), "Good morning");
+        assert_eq!(greeting_for_hour(13), "Good afternoon");
+        assert_eq!(greeting_for_hour(21), "Good evening");
+        assert_eq!(greeting_for_hour(2), "Good evening");
+    }
+
+    #[test]
+    fn apps_and_recipes_reserve_dock_padding() {
+        let mut app = test_app();
+        assert!(app.dock_can_appear());
+        app.switch_page(Page::Recipes);
+        assert!(app.dock_can_appear());
+        app.switch_page(Page::Home);
+        assert!(!app.dock_can_appear());
+        app.switch_page(Page::System);
+        assert!(!app.dock_can_appear());
+        let src = production_main();
+        assert!(src.contains("bottom: if self.dock_can_appear() { 120 } else { 40 }"));
+    }
+
+    #[test]
+    fn recent_runs_record_session_history_without_fake_rows() {
+        let mut app = test_app();
+        assert!(app.recent_runs.is_empty());
+        app.install_selected.insert(0);
+        app.record_recent_run();
+        assert_eq!(app.recent_runs.len(), 1);
+        assert_eq!(app.recent_runs[0].kind, "Install");
+        assert!(app.recent_runs[0].summary.contains("Firefox"));
+
+        app.page = Page::Recipes;
+        app.admin_selected.insert(0);
+        app.record_recent_run();
+        assert_eq!(app.recent_runs[0].kind, "Recipe");
+        assert_eq!(app.recent_runs.len(), 2);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,16 +14,15 @@ use std::{
 
 use eframe::egui::{
     self, Align, Align2, Area, Button, CentralPanel, Color32, Context, FontData, FontDefinitions,
-    FontFamily, FontId, Frame, Grid, Id, Key, Layout, Order, Painter, Panel, Pos2, Rect, RichText,
-    ScrollArea, Sense, Stroke, StrokeKind, TextEdit, TextureHandle, TextureOptions, Ui, Vec2, pos2,
-    vec2,
+    FontFamily, FontId, Frame, Id, Key, Layout, Order, Painter, Panel, Pos2, Rect, RichText,
+    ScrollArea, Sense, Stroke, StrokeKind, TextEdit, TextureHandle, TextureOptions, Ui, pos2, vec2,
 };
 
 use catalog::{AdminTask, AppEntry, CatalogLoad, Task, admin_tasks, find_base_dir, load_apps};
 use runner::{RunnerMessage, run_tasks};
 use system::{
     RemovableApp, RemovableSource, command_output, detect_package_manager, distro_name,
-    env_or_unknown, scan_removable_apps, strip_ansi, uptime, uptime_compact,
+    env_or_unknown, scan_removable_apps, strip_ansi, uptime_compact, uptime_prose,
 };
 use theme::{Palette, ThemeMode};
 use validate::{is_exec_name, is_label, zeroize_string};
@@ -114,6 +113,8 @@ const INTENT_HEIGHT: f32 = 148.0;
 const GLANCE_HEIGHT: f32 = 80.0;
 const RECIPE_CARD_HEIGHT: f32 = 148.0;
 const RECIPE_PIP: f32 = 14.0;
+const DETAIL_ROW_HEIGHT: f32 = 44.0;
+const DETAIL_LABEL_WIDTH: f32 = 200.0;
 const TITLE_SIZE: f32 = 26.0;
 const FRESH_SETUP_LABELS: &[&str] = &["Update System", "Fastfetch"];
 const LAPTOP_POWER_LABELS: &[&str] = &["TLP (Laptops)", "Powertop"];
@@ -959,22 +960,12 @@ impl ToolboxApp {
             ("OS", self.distro_name.clone()),
             ("Host", self.host.clone()),
             ("Kernel", self.kernel.clone()),
-            ("Uptime", uptime()),
+            ("Uptime", uptime_prose()),
             ("Shell", self.shell.clone()),
             ("DE/WM", self.de_wm.clone()),
             ("Package Manager", self.package_manager.clone()),
             ("App Directory", self.base_dir.display().to_string()),
         ]
-    }
-
-    fn copy_system_details(&self, ctx: &Context) {
-        let text = self
-            .system_detail_rows()
-            .into_iter()
-            .map(|(label, value)| format!("{label}: {value}"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        ctx.copy_text(text);
     }
 
     fn recipe_groups(&self) -> Vec<(String, Vec<usize>)> {
@@ -988,6 +979,19 @@ impl ToolboxApp {
             } else {
                 groups.push((task.category.clone(), vec![index]));
             }
+        }
+        for (_, items) in &mut groups {
+            items.sort_by_key(|index| {
+                (
+                    recipe_display_rank(
+                        self.admin_tasks
+                            .get(*index)
+                            .map(|task| task.label.as_str())
+                            .unwrap_or(""),
+                    ),
+                    *index,
+                )
+            });
         }
         groups
     }
@@ -1184,15 +1188,17 @@ impl ToolboxApp {
                 ui.add_space(6.0);
                 ui.label(
                     RichText::new(format!(
-                        "{} · {} · {}",
+                        "{} · {} · up {}",
                         self.kernel,
                         self.package_manager,
-                        uptime()
+                        uptime_compact()
                     ))
                     .color(palette.muted),
                 );
                 ui.add_space(20.0);
 
+                section_eyebrow(ui, "Glance", &palette);
+                ui.add_space(10.0);
                 let glance_cols = glance_columns(ui);
                 let glance_width = tile_width(ui, glance_cols);
                 for start in (0..metrics.len()).step_by(glance_cols) {
@@ -1207,32 +1213,9 @@ impl ToolboxApp {
                 }
 
                 ui.add_space(8.0);
-                Frame::new()
-                    .fill(palette.surface)
-                    .stroke(Stroke::new(1.0_f32, palette.border))
-                    .corner_radius(CARD_RADIUS)
-                    .inner_margin(egui::Margin::symmetric(18, 16))
-                    .show(ui, |ui| {
-                        ui.horizontal(|ui| {
-                            ui.label(RichText::new("Details").color(palette.text).strong());
-                            ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
-                                if ghost_button(ui, "Copy all", &palette).clicked() {
-                                    self.copy_system_details(ui.ctx());
-                                }
-                            });
-                        });
-                        ui.add_space(12.0);
-                        Grid::new("system_info_grid")
-                            .num_columns(2)
-                            .spacing(Vec2::new(28.0, 12.0))
-                            .show(ui, |ui| {
-                                for (label, value) in &rows {
-                                    ui.label(RichText::new(*label).color(palette.muted));
-                                    ui.label(RichText::new(value).color(palette.text));
-                                    ui.end_row();
-                                }
-                            });
-                    });
+                section_eyebrow(ui, "Details", &palette);
+                ui.add_space(10.0);
+                system_details_card(ui, &rows, &palette);
             });
     }
 
@@ -2081,6 +2064,57 @@ fn metric_tile(
     response
 }
 
+fn system_details_card(ui: &mut Ui, rows: &[(&'static str, String)], palette: &Palette) {
+    Frame::new()
+        .fill(palette.surface)
+        .stroke(Stroke::new(1.0_f32, palette.border))
+        .corner_radius(CARD_RADIUS)
+        .inner_margin(egui::Margin::symmetric(0, 6))
+        .show(ui, |ui| {
+            ui.set_min_width(ui.available_width());
+            for (index, (label, value)) in rows.iter().enumerate() {
+                if index > 0 {
+                    let (line, _) =
+                        ui.allocate_exact_size(vec2(ui.available_width(), 1.0), Sense::hover());
+                    ui.painter().line_segment(
+                        [
+                            pos2(line.left() + 18.0, line.center().y),
+                            pos2(line.right() - 18.0, line.center().y),
+                        ],
+                        Stroke::new(1.0_f32, palette.border),
+                    );
+                }
+                let (rect, _) = ui.allocate_exact_size(
+                    vec2(ui.available_width(), DETAIL_ROW_HEIGHT),
+                    Sense::hover(),
+                );
+                let painter = ui.painter();
+                painter.text(
+                    pos2(rect.left() + 18.0, rect.center().y),
+                    Align2::LEFT_CENTER,
+                    *label,
+                    FontId::proportional(12.0),
+                    palette.muted,
+                );
+                let value_left = rect.left() + 18.0 + DETAIL_LABEL_WIDTH;
+                let value_width = (rect.right() - 18.0 - value_left).max(24.0);
+                let galley = painter.layout(
+                    value.clone(),
+                    FontId::proportional(13.5),
+                    palette.text,
+                    value_width,
+                );
+                let text_pos = pos2(value_left, rect.center().y - galley.size().y / 2.0);
+                painter
+                    .with_clip_rect(Rect::from_min_size(
+                        pos2(value_left, rect.top()),
+                        vec2(value_width, rect.height()),
+                    ))
+                    .galley(text_pos, galley, palette.text);
+            }
+        });
+}
+
 fn paint_surface_card(painter: &Painter, rect: Rect, hovered: bool, palette: &Palette) {
     painter.rect_filled(
         rect,
@@ -2180,6 +2214,16 @@ fn recipe_chip(label: &str) -> Option<&'static str> {
         "Update System" | "SWAP Fix" => Some("CAUTION"),
         other if other.contains("Debian only") => Some("DEBIAN ONLY"),
         _ => None,
+    }
+}
+
+fn recipe_display_rank(label: &str) -> u8 {
+    match label {
+        "TLP (Laptops)" => 0,
+        "Powertop" => 1,
+        "Enable Bluetooth" => 2,
+        "Disable Bluetooth" => 3,
+        _ => 100,
     }
 }
 
@@ -3245,14 +3289,9 @@ mod tests {
             }
         }
         assert_eq!(admin_tasks().len(), 9);
-        let groups = {
-            let app = {
-                let mut app = test_app();
-                app.admin_tasks = admin_tasks();
-                app
-            };
-            app.recipe_groups()
-        };
+        let mut app = test_app();
+        app.admin_tasks = admin_tasks();
+        let groups = app.recipe_groups();
         assert_eq!(
             groups
                 .iter()
@@ -3260,10 +3299,24 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["Power Management", "System"]
         );
+        let power_labels: Vec<String> = groups[0]
+            .1
+            .iter()
+            .filter_map(|&index| app.admin_tasks.get(index).map(|task| task.label.clone()))
+            .collect();
+        assert_eq!(
+            power_labels,
+            [
+                "TLP (Laptops)",
+                "Powertop",
+                "Enable Bluetooth",
+                "Disable Bluetooth"
+            ]
+        );
     }
 
     #[test]
-    fn system_detail_keeps_live_fields_and_copy_all() {
+    fn system_detail_keeps_live_fields_without_fake_cpu() {
         let app = test_app();
         let rows = app.system_detail_rows();
         assert_eq!(rows[0].0, "OS");
@@ -3282,9 +3335,14 @@ mod tests {
             .nth(1)
             .and_then(|rest| rest.split("fn modal_count_line").next())
             .expect("system_info_page");
-        assert!(system.contains("Copy all"));
-        assert!(system.contains("copy_system_details"));
+        assert!(system.contains("Glance"));
+        assert!(system.contains("Details"));
+        assert!(system.contains("up {}"));
+        assert!(system.contains("system_details_card"));
+        assert!(!system.contains("Copy all"));
+        assert!(!system.contains("copy_system_details"));
         assert!(!system.contains("command_output"));
+        assert!(!system.contains("\"CPU\""));
         assert_eq!(greeting_for_hour(7), "Good morning");
         assert_eq!(greeting_for_hour(13), "Good afternoon");
         assert_eq!(greeting_for_hour(21), "Good evening");

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,6 +112,8 @@ const DOCK_RADIUS: f32 = 20.0;
 const CONTENT_TWO_COL: f32 = 720.0;
 const INTENT_HEIGHT: f32 = 136.0;
 const GLANCE_HEIGHT: f32 = 88.0;
+const RECIPE_CARD_HEIGHT: f32 = 148.0;
+const RECIPE_PIP: f32 = 16.0;
 const TITLE_SIZE: f32 = 26.0;
 const FRESH_SETUP_LABELS: &[&str] = &["Update System", "Fastfetch"];
 const LAPTOP_POWER_LABELS: &[&str] = &["TLP (Laptops)", "Powertop"];
@@ -121,7 +123,6 @@ enum Glyph {
     Plus,
     Bolt,
     Briefcase,
-    Sliders,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -990,12 +991,17 @@ impl ToolboxApp {
             .id_salt("home_page")
             .auto_shrink([false, false])
             .show(ui, |ui| {
-                ui.label(
-                    RichText::new(greeting())
-                        .font(FontId::proportional(TITLE_SIZE))
-                        .color(palette.text)
-                        .strong(),
-                );
+                ui.horizontal(|ui| {
+                    ui.label(
+                        RichText::new(greeting())
+                            .font(FontId::proportional(TITLE_SIZE))
+                            .color(palette.text)
+                            .strong(),
+                    );
+                    ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
+                        status_pill(ui, "System up to date", &palette);
+                    });
+                });
                 ui.add_space(8.0);
                 ui.horizontal(|ui| {
                     let (dot, _) = ui.allocate_exact_size(vec2(8.0, 8.0), Sense::hover());
@@ -1142,11 +1148,10 @@ impl ToolboxApp {
     fn recipe_tile(&mut self, ui: &mut Ui, index: usize, width: f32) {
         let task = &self.admin_tasks[index];
         let label = task.label.clone();
-        let category = task.category.clone();
         let selected = self.admin_selected.contains(&index);
         let palette = self.palette();
         let locked = self.selection_locked();
-        if recipe_card(ui, width, selected, &label, &category, &palette).clicked() && !locked {
+        if recipe_card(ui, width, selected, &label, &palette).clicked() && !locked {
             if selected {
                 self.admin_selected.remove(&index);
             } else {
@@ -1319,14 +1324,19 @@ impl ToolboxApp {
                     .show(ui, |ui| {
                         ui.set_min_width(DOCK_MIN_WIDTH);
                         ui.horizontal(|ui| {
-                            ui.spacing_mut().item_spacing.x = 8.0;
-                            ui.label(
-                                RichText::new(format!("{count}"))
-                                    .color(palette.accent)
-                                    .strong(),
-                            );
-                            ui.label(RichText::new("staged").color(palette.text).strong());
-                            ui.label(RichText::new(names).color(palette.muted));
+                            ui.spacing_mut().item_spacing.x = 12.0;
+                            ui.vertical(|ui| {
+                                ui.horizontal(|ui| {
+                                    ui.spacing_mut().item_spacing.x = 6.0;
+                                    ui.label(
+                                        RichText::new(format!("{count}"))
+                                            .color(palette.accent)
+                                            .strong(),
+                                    );
+                                    ui.label(RichText::new("staged").color(palette.text).strong());
+                                });
+                                ui.label(RichText::new(names).color(palette.muted));
+                            });
                             ui.with_layout(Layout::right_to_left(Align::Center), |ui| {
                                 if cta_button(ui, "Review & Run  →", true, &palette).clicked() {
                                     review = true;
@@ -2091,34 +2101,28 @@ fn recipe_card(
     width: f32,
     selected: bool,
     label: &str,
-    category: &str,
     palette: &Palette,
 ) -> egui::Response {
-    let (rect, response) = ui.allocate_exact_size(vec2(width, CARD_HEIGHT), Sense::click());
+    let (rect, response) = ui.allocate_exact_size(vec2(width, RECIPE_CARD_HEIGHT), Sense::click());
     paint_card_background(ui.painter(), rect, selected, palette);
 
-    let well = Rect::from_min_size(rect.min + vec2(16.0, 16.0), vec2(CARD_ICON, CARD_ICON));
+    let well = Rect::from_min_size(rect.min + vec2(16.0, 16.0), vec2(40.0, 40.0));
     ui.painter().rect_filled(well, 12.0, palette.icon_well);
-    paint_glyph(
-        ui.painter(),
-        well.shrink(10.0),
-        recipe_glyph(category),
-        palette.accent,
-    );
+    paint_glyph(ui.painter(), well.shrink(9.0), Glyph::Bolt, palette.accent);
 
-    let check_rect = Rect::from_min_size(
-        pos2(rect.right() - 16.0 - CHECK_SIZE, rect.min.y + 16.0),
-        vec2(CHECK_SIZE, CHECK_SIZE),
+    let pip_rect = Rect::from_min_size(
+        pos2(rect.right() - 16.0 - RECIPE_PIP, rect.min.y + 16.0),
+        vec2(RECIPE_PIP, RECIPE_PIP),
     );
-    paint_check(ui.painter(), check_rect, selected, palette);
+    paint_select_pip(ui.painter(), pip_rect, selected, palette);
 
     let text_left = rect.min.x + 16.0;
     let text_width = (rect.width() - 32.0).max(24.0);
     let painter = ui.painter();
     painter.text(
-        pos2(text_left, rect.min.y + 72.0),
-        Align2::LEFT_CENTER,
-        label,
+        pos2(text_left, rect.min.y + 68.0),
+        Align2::LEFT_TOP,
+        recipe_display_label(label),
         FontId::proportional(14.0),
         palette.text,
     );
@@ -2131,10 +2135,10 @@ fn recipe_card(
     );
     painter
         .with_clip_rect(Rect::from_min_size(
-            pos2(text_left, rect.min.y + 86.0),
-            vec2(text_width, 28.0),
+            pos2(text_left, rect.min.y + 88.0),
+            vec2(text_width, 24.0),
         ))
-        .galley(pos2(text_left, rect.min.y + 86.0), galley, palette.muted);
+        .galley(pos2(text_left, rect.min.y + 88.0), galley, palette.muted);
 
     if let Some(chip) = recipe_chip(label) {
         paint_warm_chip(
@@ -2148,50 +2152,99 @@ fn recipe_card(
     response
 }
 
-fn recipe_glyph(category: &str) -> Glyph {
-    if category == "Power Management" {
-        Glyph::Bolt
-    } else {
-        Glyph::Sliders
-    }
+fn recipe_display_label(label: &str) -> &str {
+    label.strip_suffix(" - Debian only").unwrap_or(label)
 }
 
 fn recipe_promise(label: &str) -> &'static str {
     match label {
-        "Enable Bluetooth" => "Turn Bluetooth on for this machine.",
-        "Disable Bluetooth" => "Turn Bluetooth off to save power.",
-        "TLP (Laptops)" => "Tune laptop power so the battery lasts.",
-        "Powertop" => "Diagnose and cut background power waste.",
-        "Update System" => "Bring packages on this machine up to date.",
-        "nala (rank mirrors) - Debian only" => "Rank Debian mirrors for faster apt.",
-        "Stacer" => "Lightweight Linux system optimizer.",
-        "SWAP Fix" => "Lower swappiness so resume stays snappy.",
-        "Fastfetch" => "Show a clean system summary in the terminal.",
+        "Enable Bluetooth" => "Turn the Bluetooth radio on",
+        "Disable Bluetooth" => "Turn the Bluetooth radio off",
+        "TLP (Laptops)" => "Install and enable laptop power tuning",
+        "Powertop" => "Install power analysis tooling",
+        "Update System" => "Full distro update now",
+        "nala (rank mirrors) - Debian only" => "Install nala and rank Debian mirrors",
+        "Stacer" => "Install system optimizer",
+        "SWAP Fix" => "Tune swappiness for this machine",
+        "Fastfetch" => "Install a clean system summary tool",
         _ => "Admin playbook for this machine.",
     }
 }
 
 fn recipe_chip(label: &str) -> Option<&'static str> {
     match label {
-        "Update System" | "SWAP Fix" => Some("Caution"),
-        other if other.contains("Debian only") => Some("Debian only"),
+        "TLP (Laptops)" => Some("LAPTOP"),
+        "Update System" | "SWAP Fix" => Some("CAUTION"),
+        other if other.contains("Debian only") => Some("DEBIAN ONLY"),
         _ => None,
     }
 }
 
+fn paint_select_pip(painter: &Painter, rect: Rect, selected: bool, palette: &Palette) {
+    let center = rect.center();
+    let radius = rect.width() / 2.0;
+    if selected {
+        painter.circle_filled(center, radius, palette.accent);
+    } else {
+        painter.circle_stroke(
+            center,
+            radius - 0.5,
+            Stroke::new(1.2_f32, palette.border_strong),
+        );
+    }
+}
+
 fn paint_warm_chip(painter: &Painter, left_center: Pos2, label: &str, palette: &Palette) {
-    let width = (label.len() as f32 * 7.2 + 16.0).clamp(56.0, 140.0);
+    let width = (label.len() as f32 * 7.0 + 18.0).clamp(56.0, 148.0);
     let rect = Rect::from_center_size(
         pos2(left_center.x + width / 2.0, left_center.y),
         vec2(width, 20.0),
     );
-    painter.rect_filled(rect, 6.0, palette.caution);
-    painter.text(
+    match palette.mode {
+        ThemeMode::Dark => {
+            painter.rect_stroke(
+                rect,
+                6.0,
+                Stroke::new(1.0_f32, palette.caution),
+                StrokeKind::Inside,
+            );
+            painter.text(
+                rect.center(),
+                Align2::CENTER_CENTER,
+                label,
+                FontId::proportional(10.0),
+                palette.caution,
+            );
+        }
+        ThemeMode::Light => {
+            painter.rect_filled(rect, 6.0, palette.caution);
+            painter.text(
+                rect.center(),
+                Align2::CENTER_CENTER,
+                label,
+                FontId::proportional(10.0),
+                palette.caution_on,
+            );
+        }
+    }
+}
+
+fn status_pill(ui: &mut Ui, label: &str, palette: &Palette) {
+    let width = (label.len() as f32 * 7.0 + 20.0).clamp(88.0, 160.0);
+    let (rect, _) = ui.allocate_exact_size(vec2(width, 26.0), Sense::hover());
+    ui.painter().rect_filled(rect, 13.0, palette.surface);
+    ui.painter().rect_stroke(
+        rect,
+        13.0,
+        Stroke::new(1.0_f32, palette.border),
+        StrokeKind::Inside,
+    );
+    ui.painter().text(
         rect.center(),
         Align2::CENTER_CENTER,
         label,
-        FontId::proportional(10.5),
-        palette.caution_on,
+        FontId::proportional(11.5),
+        palette.muted,
     );
 }
 
@@ -2270,13 +2323,6 @@ fn paint_glyph(painter: &Painter, rect: Rect, glyph: Glyph, color: Color32) {
                 stroke,
                 StrokeKind::Inside,
             );
-        }
-        Glyph::Sliders => {
-            for (y_off, knob) in [(0.22, 0.65), (0.50, 0.35), (0.78, 0.55)] {
-                let y = rect.top() + rect.height() * y_off;
-                painter.line_segment([pos2(rect.left(), y), pos2(rect.right(), y)], stroke);
-                painter.circle_filled(pos2(rect.left() + rect.width() * knob, y), 2.6, color);
-            }
         }
     }
 }
@@ -3091,6 +3137,7 @@ mod tests {
         assert!(home.contains("Jump to Recipes for essentials after a distro hop."));
         assert!(home.contains("Browse the catalog and stage what you need."));
         assert!(home.contains("TLP + Powertop tuned so the battery lasts."));
+        assert!(home.contains("System up to date"));
     }
 
     #[test]
@@ -3152,11 +3199,30 @@ mod tests {
                 task.label
             );
             match task.label.as_str() {
-                "Update System" | "SWAP Fix" => {
-                    assert_eq!(recipe_chip(&task.label), Some("Caution"));
+                "Enable Bluetooth" => {
+                    assert_eq!(promise, "Turn the Bluetooth radio on");
+                }
+                "Disable Bluetooth" => {
+                    assert_eq!(promise, "Turn the Bluetooth radio off");
+                }
+                "TLP (Laptops)" => {
+                    assert_eq!(promise, "Install and enable laptop power tuning");
+                    assert_eq!(recipe_chip(&task.label), Some("LAPTOP"));
+                }
+                "Powertop" => {
+                    assert_eq!(promise, "Install power analysis tooling");
+                }
+                "Update System" => {
+                    assert_eq!(promise, "Full distro update now");
+                    assert_eq!(recipe_chip(&task.label), Some("CAUTION"));
+                }
+                "SWAP Fix" => {
+                    assert_eq!(recipe_chip(&task.label), Some("CAUTION"));
                 }
                 other if other.contains("Debian only") => {
-                    assert_eq!(recipe_chip(&task.label), Some("Debian only"));
+                    assert_eq!(promise, "Install nala and rank Debian mirrors");
+                    assert_eq!(recipe_chip(&task.label), Some("DEBIAN ONLY"));
+                    assert_eq!(recipe_display_label(other), "nala (rank mirrors)");
                 }
                 _ => assert_eq!(recipe_chip(&task.label), None),
             }

--- a/src/system.rs
+++ b/src/system.rs
@@ -89,21 +89,37 @@ pub fn env_or_unknown(keys: &[&str]) -> String {
 }
 
 pub fn uptime() -> String {
-    let Ok(contents) = fs::read_to_string("/proc/uptime") else {
-        return "Unknown".to_owned();
-    };
-    let Some(first) = contents.split_whitespace().next() else {
-        return "Unknown".to_owned();
-    };
-    let Ok(seconds) = first.parse::<f64>() else {
-        return "Unknown".to_owned();
-    };
+    format_uptime(uptime_parts(), false)
+}
 
+pub fn uptime_compact() -> String {
+    format_uptime(uptime_parts(), true)
+}
+
+fn uptime_parts() -> Option<(u64, u64, u64)> {
+    let contents = fs::read_to_string("/proc/uptime").ok()?;
+    let first = contents.split_whitespace().next()?;
+    let seconds = first.parse::<f64>().ok()?;
     let total = seconds as u64;
-    let days = total / 86_400;
-    let hours = (total % 86_400) / 3_600;
-    let minutes = (total % 3_600) / 60;
+    Some((
+        total / 86_400,
+        (total % 86_400) / 3_600,
+        (total % 3_600) / 60,
+    ))
+}
 
+fn format_uptime(parts: Option<(u64, u64, u64)>, compact: bool) -> String {
+    let Some((days, hours, minutes)) = parts else {
+        return "Unknown".to_owned();
+    };
+    if compact {
+        return match (days, hours) {
+            (0, 0) => format!("{minutes}m"),
+            (0, _) => format!("{hours}h"),
+            (_, 0) => format!("{days}d"),
+            _ => format!("{days}d {hours}h"),
+        };
+    }
     match (days, hours) {
         (0, 0) => format!("{minutes}m"),
         (0, _) => format!("{hours}h {minutes}m"),
@@ -492,6 +508,15 @@ mod tests {
     #[test]
     fn trim_release_value_strips_quotes() {
         assert_eq!(trim_release_value("\"Arch Linux\""), "Arch Linux");
+    }
+
+    #[test]
+    fn compact_uptime_matches_glance_mock_shape() {
+        assert_eq!(format_uptime(Some((2, 4, 12)), true), "2d 4h");
+        assert_eq!(format_uptime(Some((0, 3, 12)), true), "3h");
+        assert_eq!(format_uptime(Some((0, 0, 9)), true), "9m");
+        assert_eq!(format_uptime(Some((2, 4, 12)), false), "2d 4h 12m");
+        assert_eq!(format_uptime(None, true), "Unknown");
     }
 
     #[test]

--- a/src/system.rs
+++ b/src/system.rs
@@ -88,12 +88,12 @@ pub fn env_or_unknown(keys: &[&str]) -> String {
     "Unknown".to_owned()
 }
 
-pub fn uptime() -> String {
-    format_uptime(uptime_parts(), false)
-}
-
 pub fn uptime_compact() -> String {
     format_uptime(uptime_parts(), true)
+}
+
+pub fn uptime_prose() -> String {
+    format_uptime_prose(uptime_parts())
 }
 
 fn uptime_parts() -> Option<(u64, u64, u64)> {
@@ -124,6 +124,30 @@ fn format_uptime(parts: Option<(u64, u64, u64)>, compact: bool) -> String {
         (0, 0) => format!("{minutes}m"),
         (0, _) => format!("{hours}h {minutes}m"),
         _ => format!("{days}d {hours}h {minutes}m"),
+    }
+}
+
+fn format_uptime_prose(parts: Option<(u64, u64, u64)>) -> String {
+    let Some((days, hours, minutes)) = parts else {
+        return "Unknown".to_owned();
+    };
+    match (days, hours) {
+        (0, 0) => unit_phrase(minutes, "minute", "minutes"),
+        (0, _) => unit_phrase(hours, "hour", "hours"),
+        (_, 0) => unit_phrase(days, "day", "days"),
+        _ => format!(
+            "{}, {}",
+            unit_phrase(days, "day", "days"),
+            unit_phrase(hours, "hour", "hours")
+        ),
+    }
+}
+
+fn unit_phrase(count: u64, one: &str, many: &str) -> String {
+    if count == 1 {
+        format!("1 {one}")
+    } else {
+        format!("{count} {many}")
     }
 }
 
@@ -517,6 +541,11 @@ mod tests {
         assert_eq!(format_uptime(Some((0, 0, 9)), true), "9m");
         assert_eq!(format_uptime(Some((2, 4, 12)), false), "2d 4h 12m");
         assert_eq!(format_uptime(None, true), "Unknown");
+        assert_eq!(format_uptime_prose(Some((2, 4, 12))), "2 days, 4 hours");
+        assert_eq!(format_uptime_prose(Some((1, 0, 0))), "1 day");
+        assert_eq!(format_uptime_prose(Some((0, 1, 8))), "1 hour");
+        assert_eq!(format_uptime_prose(Some((0, 0, 1))), "1 minute");
+        assert_eq!(format_uptime_prose(None), "Unknown");
     }
 
     #[test]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -26,6 +26,8 @@ pub const ACCENT_LIGHT: Color32 = Color32::from_rgb(0x0D, 0x94, 0x88);
 pub const ACCENT_BRIGHT: Color32 = Color32::from_rgb(0x2D, 0xD4, 0xBF);
 pub const ACCENT_ON_LIGHT: Color32 = Color32::from_rgb(0x04, 0x2F, 0x2E);
 pub const BORDER_LIGHT_BASE: Color32 = Color32::from_rgb(0x0F, 0x17, 0x2A);
+pub const CAUTION: Color32 = Color32::from_rgb(0xFD, 0xBA, 0x74);
+pub const CAUTION_ON: Color32 = Color32::from_rgb(0x1C, 0x14, 0x0A);
 
 const CONFIG_DIR_NAME: &str = "linux-it-guy-toolbox";
 const THEME_FILE_NAME: &str = "theme";
@@ -112,6 +114,8 @@ pub struct Palette {
     pub log_inner: Color32,
     pub log_text: Color32,
     pub surface_hover: Color32,
+    pub caution: Color32,
+    pub caution_on: Color32,
 }
 
 impl Palette {
@@ -153,6 +157,8 @@ impl Palette {
             log_inner: VOID_DARK,
             log_text: TEXT_DARK,
             surface_hover: mix(SURFACE_DARK, ELEVATED_DARK, 0.65),
+            caution: CAUTION,
+            caution_on: CAUTION_ON,
         }
     }
 
@@ -204,6 +210,8 @@ impl Palette {
             log_inner: ELEVATED_LIGHT,
             log_text: TEXT_LIGHT,
             surface_hover: mix(SURFACE_LIGHT, TEXT_LIGHT, 0.06),
+            caution: CAUTION,
+            caution_on: CAUTION_ON,
         }
     }
 
@@ -470,6 +478,8 @@ mod tests {
         assert_eq!(hex(ACCENT_BRIGHT), "#2DD4BF");
         assert_eq!(hex(ACCENT_ON_LIGHT), "#042F2E");
         assert_eq!(hex(BORDER_LIGHT_BASE), "#0F172A");
+        assert_eq!(hex(CAUTION), "#FDBA74");
+        assert_eq!(hex(CAUTION_ON), "#1C140A");
     }
 
     #[test]
@@ -510,6 +520,9 @@ mod tests {
         assert_eq!(palette.border.a(), 18);
         assert_eq!(palette.border_strong.a(), 31);
         assert_eq!(palette.accent_dim.a(), 36);
+        assert_eq!(palette.caution, CAUTION);
+        assert_eq!(palette.caution_on, CAUTION_ON);
+        assert_ne!(palette.caution, palette.cta_fill);
     }
 
     #[test]
@@ -607,6 +620,16 @@ mod tests {
             );
             assert_ne!(palette.tile, palette.void);
             assert_ne!(palette.border, palette.surface);
+            assert!(
+                contrast_ratio(palette.caution_on, palette.caution) >= 4.5,
+                "{:?} caution chip contrast",
+                palette.mode
+            );
+            assert_ne!(
+                palette.caution, palette.cta_fill,
+                "{:?} caution chips must not reuse the CTA fill",
+                palette.mode
+            );
         }
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-on to merged PR #14 (`ded15117`) Apps + Run Dock. Chrome-only Home / Recipes / System on Lumen. Navy/yellow stays gone. **Do not merge until Chris says.**

Full Poppy mock set is matched (PNGs are not embedded as assets). Live glance values come from this machine (Ubuntu / apt-get), not the Omarchy / pacman sample copy in the mocks.

## Home
Greeting, `{distro} is ready · package manager {pm}`, **System up to date** pill, three intent cards (Install apps / Fresh setup / Laptop power), SYSTEM GLANCE (OS / Kernel / Uptime / Packages — no fake CPU%), RECENT RUNS empty: “No runs yet — stage apps or a recipe to get started.”

## Recipes
Title + “One-click admin playbooks for this machine.” POWER MANAGEMENT / SYSTEM eyebrows. Display order: TLP, Powertop, Enable Bluetooth, Disable Bluetooth (`admin_tasks()` catalog order unchanged). Bolt wells, teal selection pip, outline LAPTOP / CAUTION / DEBIAN ONLY chips. Run Dock: teal `{n} staged` over catalog-order labels, Clear, pill **Review & Run →**.

## System
Distro hero, muted `{kernel} · {pm} · up {compact}`, GLANCE tiles from live helpers, DETAILS card with hairline rows (OS, Host, Kernel, Uptime as prose, Shell, DE/WM, Package Manager, App Directory). No fake CPU%.

## Verify
`cargo fmt`, `clippy -D warnings`, `cargo test --all-targets` (99 passed). GUI pass: Home → Laptop power → Recipes dock → Review & Run (cancelled) → System → Home.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d8ec234f-eda3-4e57-8057-17b1d3b1fa7a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d8ec234f-eda3-4e57-8057-17b1d3b1fa7a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

